### PR TITLE
Feature/log and reports read only

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -695,6 +695,24 @@
         "is_secret": false
       }
     ],
+    "src/rds-control-plane-mcp-server/tests/test_reports.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/rds-control-plane-mcp-server/tests/test_reports.py",
+        "hashed_secret": "e988de1eb61164b4ba5db0f741f789892ea949cf",
+        "is_verified": false,
+        "line_number": 34
+      }
+    ],
+    "src/rds-control-plane-mcp-server/tests/test_server.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/rds-control-plane-mcp-server/tests/test_server.py",
+        "hashed_secret": "e988de1eb61164b4ba5db0f741f789892ea949cf",
+        "is_verified": false,
+        "line_number": 37
+      }
+    ],
     "src/stepfunctions-tool-mcp-server/README.md": [
       {
         "type": "Base64 High Entropy String",
@@ -732,5 +750,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-17T00:43:32Z"
+  "generated_at": "2025-06-24T12:49:13Z"
 }

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/clients.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/clients.py
@@ -19,7 +19,7 @@ from typing import Optional
 
 
 def get_rds_client(
-    region_name: Optional[str] = 'us-east-1', profile_name: Optional[str] = None
+    region_name: Optional[str] = None, profile_name: Optional[str] = None
 ) -> RDSClient:
     """Get an Amazon RDS client.
 
@@ -34,16 +34,14 @@ def get_rds_client(
         An RDS client instance
     """
     if profile_name:
-        client = boto3.Session(profile_name=profile_name).client(
-            'rds', region_name=region_name or 'us-east-1'
-        )
+        client = boto3.Session(profile_name=profile_name).client('rds', region_name=region_name)
         return client  # type: ignore
-    client = boto3.client('rds', region_name=region_name or 'us-east-1')
+    client = boto3.client('rds', region_name=region_name)
     return client  # type: ignore
 
 
 def get_pi_client(
-    region_name: Optional[str] = 'us-east-1', profile_name: Optional[str] = None
+    region_name: Optional[str] = None, profile_name: Optional[str] = None
 ) -> PIClient:
     """Get a Performance Insights client.
 
@@ -57,9 +55,7 @@ def get_pi_client(
         A Performance Insights (PI) client instance
     """
     if profile_name:
-        client = boto3.Session(profile_name=profile_name).client(
-            'pi', region_name=region_name or 'us-east-1'
-        )
+        client = boto3.Session(profile_name=profile_name).client('pi', region_name=region_name)
         return client  # type: ignore
-    client = boto3.client('pi', region_name=region_name or 'us-east-1')
+    client = boto3.client('pi', region_name=region_name)
     return client  # type: ignore

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/clients.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/clients.py
@@ -1,0 +1,65 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import boto3
+from mypy_boto3_pi.client import PIClient
+from mypy_boto3_rds.client import RDSClient
+from typing import Optional
+
+
+def get_rds_client(
+    region_name: Optional[str] = 'us-east-1', profile_name: Optional[str] = None
+) -> RDSClient:
+    """Get an Amazon RDS client.
+
+    Amazon Relational Database Service (RDS) makes it easy to set up, operate,
+    and scale a relational database in the cloud.
+
+    Args:
+        region_name: The AWS region name to use for the client
+        profile_name: Optional AWS profile name to use
+
+    Returns:
+        An RDS client instance
+    """
+    if profile_name:
+        client = boto3.Session(profile_name=profile_name).client(
+            'rds', region_name=region_name or 'us-east-1'
+        )
+        return client  # type: ignore
+    client = boto3.client('rds', region_name=region_name or 'us-east-1')
+    return client  # type: ignore
+
+
+def get_pi_client(
+    region_name: Optional[str] = 'us-east-1', profile_name: Optional[str] = None
+) -> PIClient:
+    """Get a Performance Insights client.
+
+    AWS Performance Insights provides a dashboard for monitoring and analyzing database performance.
+
+    Args:
+        region_name: The AWS region name to use for the client
+        profile_name: Optional AWS profile name to use
+
+    Returns:
+        A Performance Insights (PI) client instance
+    """
+    if profile_name:
+        client = boto3.Session(profile_name=profile_name).client(
+            'pi', region_name=region_name or 'us-east-1'
+        )
+        return client  # type: ignore
+    client = boto3.client('pi', region_name=region_name or 'us-east-1')
+    return client  # type: ignore

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/config.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/config.py
@@ -1,0 +1,43 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration settings for RDS Control Plane MCP Server.
+
+This module contains settings that can be configured at runtime through
+command line arguments or environment variables.
+"""
+
+from mypy_boto3_rds.type_defs import PaginatorConfigTypeDef
+
+
+# Default values
+DEFAULT_MAX_ITEMS = 100
+DEFAULT_PAGE_SIZE = 20
+
+# Runtime configurable values (with defaults)
+max_items = DEFAULT_MAX_ITEMS
+page_size = DEFAULT_PAGE_SIZE
+
+
+# Dynamic configuration based on above values
+def get_pagination_config() -> PaginatorConfigTypeDef:
+    """Return a pagination configuration dictionary based on current settings.
+
+    Returns:
+        PaginatorConfigTypeDef: Pagination configuration for AWS client paginators
+    """
+    return {
+        'MaxItems': max_items,
+        'PageSize': page_size,
+    }

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/constants.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/constants.py
@@ -1,0 +1,33 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mypy_boto3_rds.type_defs import PaginatorConfigTypeDef
+
+
+"""Constants for RDS Control Plane MCP Server."""
+
+# MCP Server Version
+MCP_SERVER_VERSION = '0.1.0'
+
+# Error Messages
+ERROR_AWS_API = 'AWS API error: {}'
+ERROR_UNEXPECTED = 'Unexpected error: {}'
+
+# Pagination & Retrieval Limits
+
+MAX_ITEMS = 100
+PAGINATION_CONFIG: PaginatorConfigTypeDef = {
+    'MaxItems': MAX_ITEMS,
+    'PageSize': 10,
+}

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/constants.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/constants.py
@@ -29,5 +29,5 @@ ERROR_UNEXPECTED = 'Unexpected error: {}'
 MAX_ITEMS = 100
 PAGINATION_CONFIG: PaginatorConfigTypeDef = {
     'MaxItems': MAX_ITEMS,
-    'PageSize': 10,
+    'PageSize': 20,
 }

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/constants.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/constants.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mypy_boto3_rds.type_defs import PaginatorConfigTypeDef
-
-
 """Constants for RDS Control Plane MCP Server."""
 
 # MCP Server Version
@@ -23,11 +20,3 @@ MCP_SERVER_VERSION = '0.1.0'
 # Error Messages
 ERROR_AWS_API = 'AWS API error: {}'
 ERROR_UNEXPECTED = 'Unexpected error: {}'
-
-# Pagination & Retrieval Limits
-
-MAX_ITEMS = 100
-PAGINATION_CONFIG: PaginatorConfigTypeDef = {
-    'MaxItems': MAX_ITEMS,
-    'PageSize': 20,
-}

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/logs.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/logs.py
@@ -16,7 +16,7 @@
 
 from .models import DBLogFileSummary
 from .utils import handle_aws_error
-from awslabs.rds_control_plane_mcp_server.constants import PAGINATION_CONFIG
+from awslabs.rds_control_plane_mcp_server.config import get_pagination_config
 from datetime import datetime
 from mypy_boto3_rds import RDSClient
 from pydantic import Field
@@ -50,7 +50,7 @@ async def list_db_log_files(
         page_iterator = paginator.paginate(
             DBInstanceIdentifier=db_instance_identifier,
             FileSize=1,
-            PaginationConfig=PAGINATION_CONFIG,
+            PaginationConfig=get_pagination_config(),
         )
 
         log_files = []

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/logs.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/logs.py
@@ -1,0 +1,71 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This module provides functions to list non-empty log files from a database instance."""
+
+from .models import DBLogFileSummary
+from .utils import handle_aws_error
+from awslabs.rds_control_plane_mcp_server.constants import PAGINATION_CONFIG
+from datetime import datetime
+from mypy_boto3_rds import RDSClient
+from pydantic import Field
+from typing import Annotated, Any, Dict, List, Union
+
+
+async def list_db_log_files(
+    db_instance_identifier: Annotated[
+        str, Field(description='The identifier for the DB instance')
+    ],
+    rds_client: RDSClient,
+) -> Union[List[DBLogFileSummary], Dict[str, Any]]:
+    """List all non-empty log files for the database.
+
+    Args:
+        db_instance_identifier: The identifier of the DB instance.
+        rds_client: An initialized RDS client.
+        ctx: The FastMCP context object for request handling.
+
+    Returns:
+        DBLogFilesResponse: A model containing a list of DBLogFileOverview objects
+                           representing non-empty log files.
+        Dict[str, Any]: Error response if an exception occurs.
+
+    Raises:
+        ValueError: If input parameters are invalid or missing.
+    """
+    try:
+        paginator = rds_client.get_paginator('describe_db_log_files')
+        # Do not include empty database log files
+        page_iterator = paginator.paginate(
+            DBInstanceIdentifier=db_instance_identifier,
+            FileSize=1,
+            PaginationConfig=PAGINATION_CONFIG,
+        )
+
+        log_files = []
+        for response in page_iterator:
+            for log_file in response.get('DescribeDBLogFiles', []):
+                # Convert AWS response to DBLogFileOverview objects
+                log_files.append(
+                    DBLogFileSummary(
+                        log_file_name=log_file.get('LogFileName', ''),
+                        last_written=datetime.fromtimestamp(log_file.get('LastWritten', 0) / 1000),
+                        size=log_file.get('Size', 0),
+                    )
+                )
+
+        return log_files
+
+    except Exception as e:
+        return await handle_aws_error(f'list_db_log_files({db_instance_identifier})', e, None)

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/models.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/models.py
@@ -1,0 +1,70 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data models for the RDS Monitoring MCP Server."""
+
+from datetime import datetime
+from pydantic import BaseModel, Field
+from typing import Literal
+
+
+# Log Files
+
+
+class DBLogFileSummary(BaseModel):
+    """Database log file information.
+
+    This model represents an Amazon RDS database log file with its metadata,
+    including name, last modification time, and size.
+
+    Attributes:
+        log_file_name: The name of the log file in the database instance.
+        last_written: A POSIX timestamp when the last log entry was written.
+        size: Size of the log file in bytes.
+    """
+
+    log_file_name: str = Field(
+        description='Name of the log file',
+    )
+    last_written: datetime = Field(
+        description='A POSIX timestamp when the last log entry was written.'
+    )
+    size: int = Field(description='Size of the log file in bytes', ge=0)
+
+
+# Reporting
+
+
+class PerformanceReportSummary(BaseModel):
+    """Performance analysis report information.
+
+    This model represents an Amazon RDS performance analysis report with its metadata,
+    including report ID, creation time, time range of the analysis, and status.
+
+    Attributes:
+        analysis_report_id: Unique identifier for the performance report.
+        create_time: Timestamp when the report was created.
+        start_time: Start time of the performance analysis period.
+        end_time: End time of the performance analysis period.
+        status: Current status of the report (RUNNING, SUCCEEDED, or FAILED).
+    """
+
+    # Models the AnalysisReportSummaryTypeDef class which has no required fields
+    analysis_report_id: str | None = Field(
+        None, description='Unique identifier for the performance report'
+    )
+    create_time: datetime | None = Field(None, description='Time when the report was created')
+    start_time: datetime | None = Field(None, description='Start time of the analysis period')
+    end_time: datetime | None = Field(None, description='End time of the analysis period')
+    status: Literal['RUNNING', 'SUCCEEDED', 'FAILED'] | None = None

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/reports.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/reports.py
@@ -1,0 +1,97 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This module provides functions to list and read performance reports for a given DB instance."""
+
+from .constants import MAX_ITEMS
+from awslabs.rds_control_plane_mcp_server.models import PerformanceReportSummary
+from awslabs.rds_control_plane_mcp_server.utils import format_aws_response, handle_aws_error
+from mypy_boto3_pi import PIClient
+from pydantic import Field
+from typing import Annotated, Any, List, Union
+
+
+async def list_performance_reports(
+    dbi_resource_identifier: Annotated[
+        str, Field(description='The resource identifier for the DB instance')
+    ],
+    pi_client: PIClient,
+) -> Union[List[PerformanceReportSummary], dict[str, Any]]:
+    """Retrieve all performance reports for a given DB instance.
+
+    Args:
+        dbi_resource_identifier (str): The DB instance resource identifier
+        pi_client (PIClient): The AWS Performance Insights client
+
+    Returns:
+        List[PerformanceReport]: A list of performance reports for the DB instance
+    """
+    reports: List[PerformanceReportSummary] = []
+
+    try:
+        # Only get up to MAX_ITEMS reports
+        response = pi_client.list_performance_analysis_reports(
+            ServiceType='RDS', Identifier=dbi_resource_identifier, MaxResults=MAX_ITEMS
+        )
+
+        for report in response.get('AnalysisReports', []):
+            reports.append(
+                PerformanceReportSummary(
+                    analysis_report_id=report.get('AnalysisReportId'),
+                    create_time=report.get('CreateTime'),
+                    start_time=report.get('StartTime'),
+                    end_time=report.get('EndTime'),
+                    status=report.get('Status'),
+                )
+            )
+
+        return reports
+    except Exception as e:
+        return await handle_aws_error(
+            'list_performance_analysis_reports({dbi_resource_identifier})', e, None
+        )
+
+
+async def read_performance_report(
+    dbi_resource_identifier: Annotated[
+        str, Field(description='The resource identifier for the DB instance')
+    ],
+    report_id: str,
+    pi_client: PIClient,
+) -> dict[str, Any]:
+    """Retrieve a specific performance report from AWS Performance Insights.
+
+    Args:
+        dbi_resource_identifier (str): The resource identifier for the DB instance
+        report_id (str): The ID of the performance report to read
+        pi_client (PIClient): The AWS Performance Insights client
+
+    Returns:
+        dict: The complete performance report data including metrics, analysis, and recommendations
+    """
+    try:
+        response = pi_client.get_performance_analysis_report(
+            ServiceType='RDS',
+            Identifier=dbi_resource_identifier,
+            AnalysisReportId=report_id,
+            TextFormat='MARKDOWN',
+        )
+    except Exception as e:
+        return await handle_aws_error(
+            f'get_performance_analysis_report({dbi_resource_identifier}, {report_id})', e, None
+        )
+
+    # Convert TypedDict to Dict before formatting
+    formatted_response = format_aws_response(dict(response))
+    return formatted_response.get('AnalysisReport', {})

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/reports.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/reports.py
@@ -14,7 +14,7 @@
 
 """This module provides functions to list and read performance reports for a given DB instance."""
 
-from .constants import MAX_ITEMS
+from .config import max_items
 from awslabs.rds_control_plane_mcp_server.models import PerformanceReportSummary
 from awslabs.rds_control_plane_mcp_server.utils import format_aws_response, handle_aws_error
 from mypy_boto3_pi import PIClient
@@ -40,9 +40,9 @@ async def list_performance_reports(
     reports: List[PerformanceReportSummary] = []
 
     try:
-        # Only get up to MAX_ITEMS reports
+        # Only get up to max_items reports
         response = pi_client.list_performance_analysis_reports(
-            ServiceType='RDS', Identifier=dbi_resource_identifier, MaxResults=MAX_ITEMS
+            ServiceType='RDS', Identifier=dbi_resource_identifier, MaxResults=max_items
         )
 
         for report in response.get('AnalysisReports', []):

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resource_docstrings.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resource_docstrings.py
@@ -1,0 +1,128 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Resource docstrings for the RDS Control Plane MCP Server."""
+
+LIST_PERFORMANCE_REPORTS_DOCSTRING = """List all available performance reports for a specific Amazon RDS instance.
+
+<use_case>
+Use this resource to discover all available Performance Insights analysis reports for a specific RDS database instance.
+Performance reports provide detailed analysis of database performance issues, helping you identify bottlenecks and optimization opportunities.
+</use_case>
+
+<important_notes>
+1. The response provides information about performance analysis reports generated for the instance
+2. You must provide a valid DB resource identifier to retrieve reports
+3. Performance reports are only available for instances with Performance Insights enabled
+4. Reports are provided in chronological order with the most recent reports first
+5. Use the `aws-rds://db-instance/{dbi_resource_identifier}/performance_report/{report_identifier}` resource to get detailed information about a specific report
+</important_notes>
+
+## Response structure
+Returns an array of performance report objects, each containing:
+- `analysis_report_id`: Unique identifier for the performance report (string)
+- `create_time`: Time when the report was created (datetime)
+- `start_time`: Start time of the analysis period (datetime)
+- `end_time`: End time of the analysis period (datetime)
+- `status`: Current status of the report (RUNNING, SUCCEEDED, or FAILED) (string)
+- `tags`: List of tags attached to the report (array of key-value pairs)
+
+<examples>
+Example usage scenarios:
+1. Performance monitoring:
+   - List all available performance reports to identify periods of potential performance issues
+   - Track reports generated during specific time periods of interest
+
+2. Preparation for optimization:
+   - Find specific report identifiers for detailed performance analysis
+   - Monitor the status of recently generated performance reports
+   - Identify long-running or failed reports that may need investigation
+</examples>
+"""
+
+READ_PERFORMANCE_REPORT_DOCSTRING = """Read the contents of a specific performance report for a specific Amazon RDS instance.
+
+<use_case>
+Use this resource to retrieve detailed performance analysis data from a specific Performance Insights report.
+These reports contain comprehensive information about database performance issues, including root cause analysis,
+top SQL queries causing load, wait events, and recommended actions for performance optimization.
+</use_case>
+
+<important_notes>
+1. You must provide both a valid DB instance identifier and report identifier
+2. The report must be in a SUCCEEDED status to be fully readable
+3. Reports in RUNNING status may return partial results
+4. Reports in FAILED status will return error information about why the analysis failed
+5. Large reports may contain extensive data about the performance issues analyzed
+</important_notes>
+
+## Response structure
+Returns a detailed performance report object containing:
+- `AnalysisReportId`: Unique identifier for the performance report (string)
+- `ServiceType`: Service type (always 'RDS' for RDS instances) (string)
+- `CreateTime`: Time when the report was created (datetime)
+- `StartTime`: Start time of the analysis period (datetime)
+- `EndTime`: End time of the analysis period (datetime)
+- `Status`: Current status of the report (RUNNING, SUCCEEDED, or FAILED) (string)
+- `AnalysisData`: The detailed performance analysis (object)
+  - May include metrics, anomalies, query analysis, and recommendations
+- `Tags`: List of tags attached to the report (array of key-value pairs)
+
+<examples>
+Example usage scenarios:
+1. Performance troubleshooting:
+   - Analyze root causes of performance bottlenecks during a specific period
+   - Identify top resource-consuming SQL queries during performance degradation
+   - Review wait events that contributed to slowdowns
+
+2. Performance optimization:
+   - Review recommended actions to improve database performance
+   - Analyze patterns in resource usage to guide optimization efforts
+   - Document performance issues for change management or postmortem analysis
+</examples>
+"""
+
+LIST_DB_LOG_FILES_DOCSTRING = """List all available log files for a specific Amazon RDS instance.
+
+<use_case>
+Use this resource to discover all available log files for a specific RDS database instance.
+Log files provide detailed logs of database activities, helping you troubleshoot issues and monitor performance.
+</use_case>
+
+<important_notes>
+1. The response provides information about log files generated for the instance
+2. You must provide a valid DB instance identifier to retrieve log files
+3. Log files are only available for instances with logs enabled
+4. Log files are provided in chronological order with the most recent log files first
+5. Use the `aws-rds://db-instance/{dbi_resource_identifier}/log/{log_file_identifier}` resource to get detailed information about a specific log file
+</important_notes>
+
+## Response structure
+Returns an array of log file objects, each containing:
+- `log_file_identifier`: Unique identifier for the log file (string)
+- `last_write_time`: Time when the log file was last written to (datetime)
+- `size`: Size of the log file in bytes (integer)
+
+<examples>
+Example usage scenarios:
+1. Log analysis:
+   - List all available log files to identify periods of potential issues
+   - Track log files generated during specific time periods of interest
+
+2. Log troubleshooting:
+   - Find specific log file identifiers for detailed log analysis
+   - Monitor the status of recently generated log files
+   - Identify long-running or failed log files that may need investigation
+</examples>
+"""

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/server.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/server.py
@@ -16,15 +16,25 @@
 
 import os
 import sys
-from .clients import (
+from awslabs.rds_control_plane_mcp_server.clients import (
     get_pi_client,
     get_rds_client,
 )
-from .logs import list_db_log_files
-from .models import DBLogFileSummary, PerformanceReportSummary
-from .reports import list_performance_reports, read_performance_report
+from awslabs.rds_control_plane_mcp_server.logs import list_db_log_files
+from awslabs.rds_control_plane_mcp_server.models import DBLogFileSummary, PerformanceReportSummary
+from awslabs.rds_control_plane_mcp_server.reports import (
+    list_performance_reports,
+    read_performance_report,
+)
+from awslabs.rds_control_plane_mcp_server.resource_docstrings import (
+    LIST_DB_LOG_FILES_DOCSTRING,
+    LIST_PERFORMANCE_REPORTS_DOCSTRING,
+    READ_PERFORMANCE_REPORT_DOCSTRING,
+)
+from awslabs.rds_control_plane_mcp_server.utils import apply_docstring
 from loguru import logger
 from mcp.server.fastmcp import FastMCP
+from pydantic import Field
 from typing import Any, List, Union
 
 
@@ -69,45 +79,13 @@ except Exception as e:
     name='ListPerformanceReports',
     mime_type='application/json',
 )
+@apply_docstring(LIST_PERFORMANCE_REPORTS_DOCSTRING)
 async def list_performance_reports_resource(
-    dbi_resource_identifier: str,
+    dbi_resource_identifier: str = Field(
+        ..., description='The resource identifier for the DB instance'
+    ),
 ) -> Union[List[PerformanceReportSummary], dict[str, Any]]:
-    """List all available performance reports for a specific Amazon RDS instance.
-
-    <use_case>
-    Use this resource to discover all available Performance Insights analysis reports for a specific RDS database instance.
-    Performance reports provide detailed analysis of database performance issues, helping you identify bottlenecks and optimization opportunities.
-    </use_case>
-
-    <important_notes>
-    1. The response provides information about performance analysis reports generated for the instance
-    2. You must provide a valid DB resource identifier to retrieve reports
-    3. Performance reports are only available for instances with Performance Insights enabled
-    4. Reports are provided in chronological order with the most recent reports first
-    5. Use the `aws-rds://db-instance/{dbi_resource_identifier}/performance_report/{report_identifier}` resource to get detailed information about a specific report
-    </important_notes>
-
-    ## Response structure
-    Returns an array of performance report objects, each containing:
-    - `analysis_report_id`: Unique identifier for the performance report (string)
-    - `create_time`: Time when the report was created (datetime)
-    - `start_time`: Start time of the analysis period (datetime)
-    - `end_time`: End time of the analysis period (datetime)
-    - `status`: Current status of the report (RUNNING, SUCCEEDED, or FAILED) (string)
-    - `tags`: List of tags attached to the report (array of key-value pairs)
-
-    <examples>
-    Example usage scenarios:
-    1. Performance monitoring:
-       - List all available performance reports to identify periods of potential performance issues
-       - Track reports generated during specific time periods of interest
-
-    2. Preparation for optimization:
-       - Find specific report identifiers for detailed performance analysis
-       - Monitor the status of recently generated performance reports
-       - Identify long-running or failed reports that may need investigation
-    </examples>
-    """
+    """List all available performance reports for a specific Amazon RDS instance."""
     return await list_performance_reports(
         dbi_resource_identifier,
         pi_client,
@@ -119,50 +97,16 @@ async def list_performance_reports_resource(
     name='ReadPerformanceReport',
     mime_type='text/plain',
 )
+@apply_docstring(READ_PERFORMANCE_REPORT_DOCSTRING)
 async def read_performance_report_resource(
-    dbi_resource_identifier: str, report_identifier: str
+    dbi_resource_identifier: str = Field(
+        ..., description='The resource identifier for the DB instance'
+    ),
+    report_identifier: str = Field(
+        ..., description='The identifier for the report you want to read'
+    ),
 ) -> dict[str, Any]:
-    """Read the contents of a specific performance report for a specific Amazon RDS instance.
-
-    <use_case>
-    Use this resource to retrieve detailed performance analysis data from a specific Performance Insights report.
-    These reports contain comprehensive information about database performance issues, including root cause analysis,
-    top SQL queries causing load, wait events, and recommended actions for performance optimization.
-    </use_case>
-
-    <important_notes>
-    1. You must provide both a valid DB instance identifier and report identifier
-    2. The report must be in a SUCCEEDED status to be fully readable
-    3. Reports in RUNNING status may return partial results
-    4. Reports in FAILED status will return error information about why the analysis failed
-    5. Large reports may contain extensive data about the performance issues analyzed
-    </important_notes>
-
-    ## Response structure
-    Returns a detailed performance report object containing:
-    - `AnalysisReportId`: Unique identifier for the performance report (string)
-    - `ServiceType`: Service type (always 'RDS' for RDS instances) (string)
-    - `CreateTime`: Time when the report was created (datetime)
-    - `StartTime`: Start time of the analysis period (datetime)
-    - `EndTime`: End time of the analysis period (datetime)
-    - `Status`: Current status of the report (RUNNING, SUCCEEDED, or FAILED) (string)
-    - `AnalysisData`: The detailed performance analysis (object)
-      - May include metrics, anomalies, query analysis, and recommendations
-    - `Tags`: List of tags attached to the report (array of key-value pairs)
-
-    <examples>
-    Example usage scenarios:
-    1. Performance troubleshooting:
-       - Analyze root causes of performance bottlenecks during a specific period
-       - Identify top resource-consuming SQL queries during performance degradation
-       - Review wait events that contributed to slowdowns
-
-    2. Performance optimization:
-       - Review recommended actions to improve database performance
-       - Analyze patterns in resource usage to guide optimization efforts
-       - Document performance issues for change management or postmortem analysis
-    </examples>
-    """
+    """Read the contents of a specific performance report for a specific Amazon RDS instance."""
     return await read_performance_report(
         dbi_resource_identifier=dbi_resource_identifier,
         report_id=report_identifier,
@@ -175,42 +119,11 @@ async def read_performance_report_resource(
     name='ListDBLogFiles',
     mime_type='application/json',
 )
+@apply_docstring(LIST_DB_LOG_FILES_DOCSTRING)
 async def list_db_log_files_resource(
-    db_instance_identifier: str,
+    db_instance_identifier: str = Field(..., description='The identifier for the DB instance'),
 ) -> Union[List[DBLogFileSummary], dict[str, Any]]:
-    """List all available log files for a specific Amazon RDS instance.
-
-    <use_case>
-    Use this resource to discover all available log files for a specific RDS database instance.
-    Log files provide detailed logs of database activities, helping you troubleshoot issues and monitor performance.
-    </use_case>
-
-    <important_notes>
-    1. The response provides information about log files generated for the instance
-    2. You must provide a valid DB instance identifier to retrieve log files
-    3. Log files are only available for instances with logs enabled
-    4. Log files are provided in chronological order with the most recent log files first
-    5. Use the `aws-rds://db-instance/{dbi_resource_identifier}/log/{log_file_identifier}` resource to get detailed information about a specific log file
-    </important_notes>
-
-    ## Response structure
-    Returns an array of log file objects, each containing:
-    - `log_file_identifier`: Unique identifier for the log file (string)
-    - `last_write_time`: Time when the log file was last written to (datetime)
-    - `size`: Size of the log file in bytes (integer)
-
-    <examples>
-    Example usage scenarios:
-    1. Log analysis:
-       - List all available log files to identify periods of potential issues
-       - Track log files generated during specific time periods of interest
-
-    2. Log troubleshooting:
-       - Find specific log file identifiers for detailed log analysis
-       - Monitor the status of recently generated log files
-       - Identify long-running or failed log files that may need investigation
-    </examples>
-    """
+    """List all available log files for a specific Amazon RDS instance."""
     return await list_db_log_files(
         db_instance_identifier=db_instance_identifier, rds_client=rds_client
     )

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/server.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/server.py
@@ -14,8 +14,10 @@
 
 """awslabs rds-control-plane MCP Server implementation."""
 
+import argparse
 import os
 import sys
+from awslabs.rds_control_plane_mcp_server import config
 from awslabs.rds_control_plane_mcp_server.clients import (
     get_pi_client,
     get_rds_client,
@@ -131,6 +133,22 @@ async def list_db_log_files_resource(
 
 def main():
     """Run the MCP server with CLI argument support."""
+    parser = argparse.ArgumentParser(
+        description='An AWS Labs Model Context Protocol (MCP) server for RDS Control Plane Operations'
+    )
+    parser.add_argument(
+        '--max-items',
+        type=int,
+        default=config.DEFAULT_MAX_ITEMS,
+        help=f'The maximum number of items (logs, reports, etc.) to retrieve (default: {config.DEFAULT_MAX_ITEMS})',
+    )
+    parser.add_argument('--transport', help='Transport to use for the MCP server')
+    args = parser.parse_args()
+
+    # Update the configuration with user-provided values
+    config.max_items = args.max_items
+
+    logger.info(f'Starting RDS Control Plane MCP server with max_items={config.max_items}')
     mcp.run()
 
 

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/server.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/server.py
@@ -51,21 +51,6 @@ from pydantic import Field
 from typing import Any, List, Union
 
 
-# global variables
-# _rds_client = None
-
-
-# def get_rds_client():
-#     """Get or create RDS client."""
-#     global _rds_client, _region
-#     if _rds_client is None:
-#         config = Config(
-#             region_name=_region,
-#             retries={'max_attempts': 3, 'mode': 'adaptive'},
-#         )
-#         _rds_client = boto3.client('rds', config=config)
-#     return _rds_client
-
 mcp = FastMCP(
     'awslabs.rds-control-plane-mcp-server',
     version=MCP_SERVER_VERSION,

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/server.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/server.py
@@ -14,11 +14,21 @@
 
 """awslabs rds-control-plane MCP Server implementation."""
 
+import os
+import sys
+from .clients import (
+    get_pi_client,
+    get_rds_client,
+)
+from .logs import list_db_log_files
+from .models import DBLogFileSummary, PerformanceReportSummary
+from .reports import list_performance_reports, read_performance_report
 from loguru import logger
 from mcp.server.fastmcp import FastMCP
-from typing import Literal
+from typing import Any, List, Union
 
 
+# TODO: Update instructions after PR to add discovery tools has been merged
 mcp = FastMCP(
     'awslabs.rds-control-plane-mcp-server',
     instructions='Instructions for using this rds-control-plane MCP server. This can be used by clients to improve the LLM'
@@ -28,74 +38,186 @@ mcp = FastMCP(
     dependencies=[
         'pydantic',
         'loguru',
+        'boto3',
     ],
 )
 
+# Remove all default handlers then add our own
+logger.remove()
+logger.add(sys.stderr, level='INFO')
 
-@mcp.tool(name='ExampleTool')
-async def example_tool(
-    query: str,
-) -> str:
-    """Example tool implementation.
+global pi_client
+global rds_client
+global cloudwatch_client
 
-    Replace this with your own tool implementation.
+try:
+    pi_client = get_pi_client(
+        region_name=os.getenv('AWS_REGION'),
+        profile_name=os.getenv('AWS_PROFILE'),
+    )
+    rds_client = get_rds_client(
+        region_name=os.getenv('AWS_REGION'),
+        profile_name=os.getenv('AWS_PROFILE'),
+    )
+except Exception as e:
+    logger.error(f'Error getting RDS or PI clients: {e}')
+    raise e
+
+
+@mcp.resource(
+    uri='aws-rds://db-instance/{dbi_resource_identifier}/performance_report',
+    name='ListPerformanceReports',
+    mime_type='application/json',
+)
+async def list_performance_reports_resource(
+    dbi_resource_identifier: str,
+) -> Union[List[PerformanceReportSummary], dict[str, Any]]:
+    """List all available performance reports for a specific Amazon RDS instance.
+
+    <use_case>
+    Use this resource to discover all available Performance Insights analysis reports for a specific RDS database instance.
+    Performance reports provide detailed analysis of database performance issues, helping you identify bottlenecks and optimization opportunities.
+    </use_case>
+
+    <important_notes>
+    1. The response provides information about performance analysis reports generated for the instance
+    2. You must provide a valid DB resource identifier to retrieve reports
+    3. Performance reports are only available for instances with Performance Insights enabled
+    4. Reports are provided in chronological order with the most recent reports first
+    5. Use the `aws-rds://db-instance/{dbi_resource_identifier}/performance_report/{report_identifier}` resource to get detailed information about a specific report
+    </important_notes>
+
+    ## Response structure
+    Returns an array of performance report objects, each containing:
+    - `analysis_report_id`: Unique identifier for the performance report (string)
+    - `create_time`: Time when the report was created (datetime)
+    - `start_time`: Start time of the analysis period (datetime)
+    - `end_time`: End time of the analysis period (datetime)
+    - `status`: Current status of the report (RUNNING, SUCCEEDED, or FAILED) (string)
+    - `tags`: List of tags attached to the report (array of key-value pairs)
+
+    <examples>
+    Example usage scenarios:
+    1. Performance monitoring:
+       - List all available performance reports to identify periods of potential performance issues
+       - Track reports generated during specific time periods of interest
+
+    2. Preparation for optimization:
+       - Find specific report identifiers for detailed performance analysis
+       - Monitor the status of recently generated performance reports
+       - Identify long-running or failed reports that may need investigation
+    </examples>
     """
-    project_name = 'awslabs rds-control-plane MCP Server'
-    return (
-        f"Hello from {project_name}! Your query was {query}. Replace this with your tool's logic"
+    return await list_performance_reports(
+        dbi_resource_identifier,
+        pi_client,
     )
 
 
-@mcp.tool(name='MathTool')
-async def math_tool(
-    operation: Literal['add', 'subtract', 'multiply', 'divide'],
-    a: int | float,
-    b: int | float,
-) -> int | float:
-    """Math tool implementation.
+@mcp.resource(
+    uri='aws-rds://db-instance/{dbi_resource_identifier}/performance_report/{report_identifier}',
+    name='ReadPerformanceReport',
+    mime_type='text/plain',
+)
+async def read_performance_report_resource(
+    dbi_resource_identifier: str, report_identifier: str
+) -> dict[str, Any]:
+    """Read the contents of a specific performance report for a specific Amazon RDS instance.
 
-    This tool supports the following operations:
-    - add
-    - subtract
-    - multiply
-    - divide
+    <use_case>
+    Use this resource to retrieve detailed performance analysis data from a specific Performance Insights report.
+    These reports contain comprehensive information about database performance issues, including root cause analysis,
+    top SQL queries causing load, wait events, and recommended actions for performance optimization.
+    </use_case>
 
-    Parameters:
-        operation (Literal["add", "subtract", "multiply", "divide"]): The operation to perform.
-        a (int): The first number.
-        b (int): The second number.
+    <important_notes>
+    1. You must provide both a valid DB instance identifier and report identifier
+    2. The report must be in a SUCCEEDED status to be fully readable
+    3. Reports in RUNNING status may return partial results
+    4. Reports in FAILED status will return error information about why the analysis failed
+    5. Large reports may contain extensive data about the performance issues analyzed
+    </important_notes>
 
-    Returns:
-        The result of the operation.
+    ## Response structure
+    Returns a detailed performance report object containing:
+    - `AnalysisReportId`: Unique identifier for the performance report (string)
+    - `ServiceType`: Service type (always 'RDS' for RDS instances) (string)
+    - `CreateTime`: Time when the report was created (datetime)
+    - `StartTime`: Start time of the analysis period (datetime)
+    - `EndTime`: End time of the analysis period (datetime)
+    - `Status`: Current status of the report (RUNNING, SUCCEEDED, or FAILED) (string)
+    - `AnalysisData`: The detailed performance analysis (object)
+      - May include metrics, anomalies, query analysis, and recommendations
+    - `Tags`: List of tags attached to the report (array of key-value pairs)
+
+    <examples>
+    Example usage scenarios:
+    1. Performance troubleshooting:
+       - Analyze root causes of performance bottlenecks during a specific period
+       - Identify top resource-consuming SQL queries during performance degradation
+       - Review wait events that contributed to slowdowns
+
+    2. Performance optimization:
+       - Review recommended actions to improve database performance
+       - Analyze patterns in resource usage to guide optimization efforts
+       - Document performance issues for change management or postmortem analysis
+    </examples>
     """
-    match operation:
-        case 'add':
-            return a + b
-        case 'subtract':
-            return a - b
-        case 'multiply':
-            return a * b
-        case 'divide':
-            try:
-                return a / b
-            except ZeroDivisionError:
-                raise ValueError(f'The denominator {b} cannot be zero.')
-        case _:
-            raise ValueError(
-                f'Invalid operation: {operation} (must be one of: add, subtract, multiply, divide)'
-            )
+    return await read_performance_report(
+        dbi_resource_identifier=dbi_resource_identifier,
+        report_id=report_identifier,
+        pi_client=pi_client,
+    )
+
+
+@mcp.resource(
+    uri='aws-rds://db-instance/{db_instance_identifier}/log',
+    name='ListDBLogFiles',
+    mime_type='application/json',
+)
+async def list_db_log_files_resource(
+    db_instance_identifier: str,
+) -> Union[List[DBLogFileSummary], dict[str, Any]]:
+    """List all available log files for a specific Amazon RDS instance.
+
+    <use_case>
+    Use this resource to discover all available log files for a specific RDS database instance.
+    Log files provide detailed logs of database activities, helping you troubleshoot issues and monitor performance.
+    </use_case>
+
+    <important_notes>
+    1. The response provides information about log files generated for the instance
+    2. You must provide a valid DB instance identifier to retrieve log files
+    3. Log files are only available for instances with logs enabled
+    4. Log files are provided in chronological order with the most recent log files first
+    5. Use the `aws-rds://db-instance/{dbi_resource_identifier}/log/{log_file_identifier}` resource to get detailed information about a specific log file
+    </important_notes>
+
+    ## Response structure
+    Returns an array of log file objects, each containing:
+    - `log_file_identifier`: Unique identifier for the log file (string)
+    - `last_write_time`: Time when the log file was last written to (datetime)
+    - `size`: Size of the log file in bytes (integer)
+
+    <examples>
+    Example usage scenarios:
+    1. Log analysis:
+       - List all available log files to identify periods of potential issues
+       - Track log files generated during specific time periods of interest
+
+    2. Log troubleshooting:
+       - Find specific log file identifiers for detailed log analysis
+       - Monitor the status of recently generated log files
+       - Identify long-running or failed log files that may need investigation
+    </examples>
+    """
+    return await list_db_log_files(
+        db_instance_identifier=db_instance_identifier, rds_client=rds_client
+    )
 
 
 def main():
     """Run the MCP server with CLI argument support."""
-    logger.trace('A trace message.')
-    logger.debug('A debug message.')
-    logger.info('An info message.')
-    logger.success('A success message.')
-    logger.warning('A warning message.')
-    logger.error('An error message.')
-    logger.critical('A critical message.')
-
     mcp.run()
 
 

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/utils.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/utils.py
@@ -16,9 +16,10 @@
 
 from .constants import ERROR_AWS_API, ERROR_UNEXPECTED
 from botocore.exceptions import ClientError
+from functools import wraps
 from loguru import logger
 from mcp.server.fastmcp import Context
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 
 def format_aws_response(response: Dict[str, Any]) -> Dict[str, Any]:
@@ -56,6 +57,31 @@ def convert_datetime_to_string(obj: Any) -> Any:
     elif isinstance(obj, list):
         return [convert_datetime_to_string(item) for item in obj]
     return obj
+
+
+def apply_docstring(docstring: str) -> Callable:
+    """Decorator to apply an external docstring to a function.
+
+    This decorator should be the innermost decorator applied to a function
+    (below the @mcp.resource decorator) to ensure the MCP framework sees the
+    updated docstring.
+
+    Args:
+        docstring: The docstring to apply to the function
+
+    Returns:
+        Decorator function that applies the docstring
+    """
+
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        wrapper.__doc__ = docstring
+        return wrapper
+
+    return decorator
 
 
 async def handle_aws_error(

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/utils.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/utils.py
@@ -1,0 +1,101 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility functions for the RDS Control Plane MCP Server."""
+
+from .constants import ERROR_AWS_API, ERROR_UNEXPECTED
+from botocore.exceptions import ClientError
+from loguru import logger
+from mcp.server.fastmcp import Context
+from typing import Any, Dict, Optional
+
+
+def format_aws_response(response: Dict[str, Any]) -> Dict[str, Any]:
+    """Format AWS API response for MCP.
+
+    Args:
+        response: Raw AWS API response
+
+    Returns:
+        Formatted response dictionary
+    """
+    # remove ResponseMetadata as it's not useful for LLMs
+    if 'ResponseMetadata' in response:
+        del response['ResponseMetadata']
+
+    # convert datetime objects to strings
+    return convert_datetime_to_string(response)
+
+
+def convert_datetime_to_string(obj: Any) -> Any:
+    """Recursively convert datetime objects to ISO format strings.
+
+    Args:
+        obj: Object to convert
+
+    Returns:
+        Object with datetime objects converted to strings
+    """
+    import datetime
+
+    if isinstance(obj, datetime.datetime):
+        return obj.isoformat()
+    elif isinstance(obj, dict):
+        return {k: convert_datetime_to_string(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [convert_datetime_to_string(item) for item in obj]
+    return obj
+
+
+async def handle_aws_error(
+    operation: str, error: Exception, ctx: Optional[Context] = None
+) -> Dict[str, Any]:
+    """Handle AWS API errors consistently.
+
+    Args:
+        operation: The operation that failed
+        error: The exception that was raised
+        ctx: MCP context for error reporting
+
+    Returns:
+        Error response dictionary
+    """
+    if isinstance(error, ClientError):
+        error_code = error.response['Error']['Code']
+        error_message = error.response['Error']['Message']
+        logger.error(f'{operation} failed with AWS error {error_code}: {error_message}')
+
+        error_response = {
+            'error': ERROR_AWS_API.format(error_code),
+            'error_code': error_code,
+            'error_message': error_message,
+            'operation': operation,
+        }
+
+        if ctx:
+            await ctx.error(f'{error_code}: {error_message}')
+
+    else:
+        logger.exception(f'{operation} failed with unexpected error')
+        error_response = {
+            'error': ERROR_UNEXPECTED.format(str(error)),
+            'error_type': type(error).__name__,
+            'error_message': str(error),
+            'operation': operation,
+        }
+
+        if ctx:
+            await ctx.error(str(error))
+
+    return error_response

--- a/src/rds-control-plane-mcp-server/tests/conftest.py
+++ b/src/rds-control-plane-mcp-server/tests/conftest.py
@@ -1,0 +1,65 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test fixtures for the rds-monitoring-mcp-server tests."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+@pytest.fixture
+def mock_pi_client():
+    """Create a mock Performance Insights client."""
+    client = MagicMock()
+    client.meta.region_name = 'us-east-1'
+    return client
+
+
+@pytest.fixture
+def mock_rds_client():
+    """Create a mock RDS client."""
+    client = MagicMock()
+    client.meta.region_name = 'us-east-1'
+    return client
+
+
+@pytest.fixture
+def mock_boto3():
+    """Create a mock boto3 module."""
+    with patch('boto3.client') as mock_client, patch('boto3.Session') as mock_session:
+        mock_pi = MagicMock()
+        mock_rds = MagicMock()
+        mock_cloudwatch = MagicMock()
+
+        mock_client.side_effect = lambda service, region_name=None: {
+            'pi': mock_pi,
+            'rds': mock_rds,
+            'cloudwatch': mock_cloudwatch,
+        }[service]
+
+        mock_session_instance = MagicMock()
+        mock_session_instance.client.side_effect = lambda service, region_name=None: {
+            'pi': mock_pi,
+            'rds': mock_rds,
+            'cloudwatch': mock_cloudwatch,
+        }[service]
+        mock_session.return_value = mock_session_instance
+
+        yield {
+            'client': mock_client,
+            'Session': mock_session,
+            'pi': mock_pi,
+            'rds': mock_rds,
+            'cloudwatch': mock_cloudwatch,
+        }

--- a/src/rds-control-plane-mcp-server/tests/test_clients.py
+++ b/src/rds-control-plane-mcp-server/tests/test_clients.py
@@ -38,7 +38,7 @@ class TestGetRDSClient:
     def test_get_rds_client_default(self, mock_boto3):
         """Test getting an RDS client with default parameters."""
         client = get_rds_client()
-        mock_boto3['client'].assert_called_once_with('rds', region_name='us-east-1')
+        mock_boto3['client'].assert_called_once_with('rds', region_name=None)
         assert client == mock_boto3['rds']
 
     def test_get_rds_client_with_region(self, mock_boto3):
@@ -51,9 +51,7 @@ class TestGetRDSClient:
         """Test getting an RDS client with a specific profile."""
         client = get_rds_client(profile_name='test-profile')
         mock_boto3['Session'].assert_called_once_with(profile_name='test-profile')
-        mock_boto3['Session'].return_value.client.assert_called_once_with(
-            'rds', region_name='us-east-1'
-        )
+        mock_boto3['Session'].return_value.client.assert_called_once_with('rds', region_name=None)
         assert client == mock_boto3['rds']
 
     def test_get_rds_client_with_region_and_profile(self, mock_boto3):
@@ -68,7 +66,7 @@ class TestGetRDSClient:
     def test_get_rds_client_with_none_region(self, mock_boto3):
         """Test getting an RDS client with None region."""
         client = get_rds_client(region_name=None)
-        mock_boto3['client'].assert_called_once_with('rds', region_name='us-east-1')
+        mock_boto3['client'].assert_called_once_with('rds', region_name=None)
         assert client == mock_boto3['rds']
 
 
@@ -78,7 +76,7 @@ class TestGetPIClient:
     def test_get_pi_client_default(self, mock_boto3):
         """Test getting a PI client with default parameters."""
         client = get_pi_client()
-        mock_boto3['client'].assert_called_once_with('pi', region_name='us-east-1')
+        mock_boto3['client'].assert_called_once_with('pi', region_name=None)
         assert client == mock_boto3['pi']
 
     def test_get_pi_client_with_region(self, mock_boto3):
@@ -91,9 +89,7 @@ class TestGetPIClient:
         """Test getting a PI client with a specific profile."""
         client = get_pi_client(profile_name='test-profile')
         mock_boto3['Session'].assert_called_once_with(profile_name='test-profile')
-        mock_boto3['Session'].return_value.client.assert_called_once_with(
-            'pi', region_name='us-east-1'
-        )
+        mock_boto3['Session'].return_value.client.assert_called_once_with('pi', region_name=None)
         assert client == mock_boto3['pi']
 
     def test_get_pi_client_with_region_and_profile(self, mock_boto3):
@@ -108,5 +104,5 @@ class TestGetPIClient:
     def test_get_pi_client_with_none_region(self, mock_boto3):
         """Test getting a PI client with None region."""
         client = get_pi_client(region_name=None)
-        mock_boto3['client'].assert_called_once_with('pi', region_name='us-east-1')
+        mock_boto3['client'].assert_called_once_with('pi', region_name=None)
         assert client == mock_boto3['pi']

--- a/src/rds-control-plane-mcp-server/tests/test_clients.py
+++ b/src/rds-control-plane-mcp-server/tests/test_clients.py
@@ -1,0 +1,112 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the clients module of the rds-monitoring-mcp-server."""
+
+from awslabs.rds_control_plane_mcp_server.clients import (
+    get_pi_client,
+    get_rds_client,
+)
+
+
+class TestTypeDefinitions:
+    """Tests for type definitions in clients.py."""
+
+    def test_type_definitions(self):
+        """Test that the type definitions are properly defined."""
+        from awslabs.rds_control_plane_mcp_server import clients
+
+        # Verify that the type aliases are imported
+        assert hasattr(clients, 'PIClient')
+        assert hasattr(clients, 'RDSClient')
+
+
+class TestGetRDSClient:
+    """Tests for the get_rds_client function."""
+
+    def test_get_rds_client_default(self, mock_boto3):
+        """Test getting an RDS client with default parameters."""
+        client = get_rds_client()
+        mock_boto3['client'].assert_called_once_with('rds', region_name='us-east-1')
+        assert client == mock_boto3['rds']
+
+    def test_get_rds_client_with_region(self, mock_boto3):
+        """Test getting an RDS client with a specific region."""
+        client = get_rds_client(region_name='us-east-1')
+        mock_boto3['client'].assert_called_once_with('rds', region_name='us-east-1')
+        assert client == mock_boto3['rds']
+
+    def test_get_rds_client_with_profile(self, mock_boto3):
+        """Test getting an RDS client with a specific profile."""
+        client = get_rds_client(profile_name='test-profile')
+        mock_boto3['Session'].assert_called_once_with(profile_name='test-profile')
+        mock_boto3['Session'].return_value.client.assert_called_once_with(
+            'rds', region_name='us-east-1'
+        )
+        assert client == mock_boto3['rds']
+
+    def test_get_rds_client_with_region_and_profile(self, mock_boto3):
+        """Test getting an RDS client with a specific region and profile."""
+        client = get_rds_client(region_name='us-east-1', profile_name='test-profile')
+        mock_boto3['Session'].assert_called_once_with(profile_name='test-profile')
+        mock_boto3['Session'].return_value.client.assert_called_once_with(
+            'rds', region_name='us-east-1'
+        )
+        assert client == mock_boto3['rds']
+
+    def test_get_rds_client_with_none_region(self, mock_boto3):
+        """Test getting an RDS client with None region."""
+        client = get_rds_client(region_name=None)
+        mock_boto3['client'].assert_called_once_with('rds', region_name='us-east-1')
+        assert client == mock_boto3['rds']
+
+
+class TestGetPIClient:
+    """Tests for the get_pi_client function."""
+
+    def test_get_pi_client_default(self, mock_boto3):
+        """Test getting a PI client with default parameters."""
+        client = get_pi_client()
+        mock_boto3['client'].assert_called_once_with('pi', region_name='us-east-1')
+        assert client == mock_boto3['pi']
+
+    def test_get_pi_client_with_region(self, mock_boto3):
+        """Test getting a PI client with a specific region."""
+        client = get_pi_client(region_name='us-east-1')
+        mock_boto3['client'].assert_called_once_with('pi', region_name='us-east-1')
+        assert client == mock_boto3['pi']
+
+    def test_get_pi_client_with_profile(self, mock_boto3):
+        """Test getting a PI client with a specific profile."""
+        client = get_pi_client(profile_name='test-profile')
+        mock_boto3['Session'].assert_called_once_with(profile_name='test-profile')
+        mock_boto3['Session'].return_value.client.assert_called_once_with(
+            'pi', region_name='us-east-1'
+        )
+        assert client == mock_boto3['pi']
+
+    def test_get_pi_client_with_region_and_profile(self, mock_boto3):
+        """Test getting a PI client with a specific region and profile."""
+        client = get_pi_client(region_name='us-east-1', profile_name='test-profile')
+        mock_boto3['Session'].assert_called_once_with(profile_name='test-profile')
+        mock_boto3['Session'].return_value.client.assert_called_once_with(
+            'pi', region_name='us-east-1'
+        )
+        assert client == mock_boto3['pi']
+
+    def test_get_pi_client_with_none_region(self, mock_boto3):
+        """Test getting a PI client with None region."""
+        client = get_pi_client(region_name=None)
+        mock_boto3['client'].assert_called_once_with('pi', region_name='us-east-1')
+        assert client == mock_boto3['pi']

--- a/src/rds-control-plane-mcp-server/tests/test_logs.py
+++ b/src/rds-control-plane-mcp-server/tests/test_logs.py
@@ -15,7 +15,7 @@
 """Tests for the logs module which handles RDS database log file operations."""
 
 import pytest
-from awslabs.rds_control_plane_mcp_server.constants import PAGINATION_CONFIG
+from awslabs.rds_control_plane_mcp_server.config import get_pagination_config
 from awslabs.rds_control_plane_mcp_server.logs import list_db_log_files
 from awslabs.rds_control_plane_mcp_server.models import DBLogFileSummary
 from datetime import datetime
@@ -54,7 +54,7 @@ class TestListDBLogFiles:
         mock_paginator.paginate.assert_called_once_with(
             DBInstanceIdentifier=db_instance_identifier,
             FileSize=1,
-            PaginationConfig=PAGINATION_CONFIG,
+            PaginationConfig=get_pagination_config(),
         )
 
         assert isinstance(result, list)

--- a/src/rds-control-plane-mcp-server/tests/test_logs.py
+++ b/src/rds-control-plane-mcp-server/tests/test_logs.py
@@ -1,0 +1,144 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the logs module which handles RDS database log file operations."""
+
+import pytest
+from awslabs.rds_control_plane_mcp_server.constants import PAGINATION_CONFIG
+from awslabs.rds_control_plane_mcp_server.logs import list_db_log_files
+from awslabs.rds_control_plane_mcp_server.models import DBLogFileSummary
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestListDBLogFiles:
+    """Tests for the list_db_log_files function."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_rds_client):
+        """Test successful retrieval and processing of log files."""
+        db_instance_identifier = 'test-instance'
+        mock_log_files = [
+            {
+                'LogFileName': 'log1.log',
+                'LastWritten': 1624500000000,  # milliseconds since epoch
+                'Size': 1024,
+            },
+            {
+                'LogFileName': 'log2.log',
+                'LastWritten': 1624600000000,
+                'Size': 2048,
+            },
+        ]
+
+        mock_paginator = MagicMock()
+        mock_page_iterator = MagicMock()
+        mock_paginator.paginate.return_value = mock_page_iterator
+        mock_page_iterator.__iter__.return_value = [{'DescribeDBLogFiles': mock_log_files}]
+        mock_rds_client.get_paginator.return_value = mock_paginator
+
+        result = await list_db_log_files(db_instance_identifier, mock_rds_client)
+
+        mock_rds_client.get_paginator.assert_called_once_with('describe_db_log_files')
+        mock_paginator.paginate.assert_called_once_with(
+            DBInstanceIdentifier=db_instance_identifier,
+            FileSize=1,
+            PaginationConfig=PAGINATION_CONFIG,
+        )
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+        assert isinstance(result[0], DBLogFileSummary)
+        assert result[0].log_file_name == 'log1.log'
+        assert result[0].size == 1024
+        assert result[0].last_written == datetime.fromtimestamp(1624500000000 / 1000)
+
+        assert isinstance(result[1], DBLogFileSummary)
+        assert result[1].log_file_name == 'log2.log'
+        assert result[1].size == 2048
+        assert result[1].last_written == datetime.fromtimestamp(1624600000000 / 1000)
+
+    @pytest.mark.asyncio
+    async def test_empty_response(self, mock_rds_client):
+        """Test handling of empty response from RDS API."""
+        db_instance_identifier = 'test-instance'
+
+        mock_paginator = MagicMock()
+        mock_page_iterator = MagicMock()
+        mock_paginator.paginate.return_value = mock_page_iterator
+        mock_page_iterator.__iter__.return_value = [{'DescribeDBLogFiles': []}]
+        mock_rds_client.get_paginator.return_value = mock_paginator
+
+        result = await list_db_log_files(db_instance_identifier, mock_rds_client)
+
+        assert isinstance(result, list)
+        assert len(result) == 0
+
+    @pytest.mark.asyncio
+    async def test_multiple_pages(self, mock_rds_client):
+        """Test handling of paginated results from RDS API."""
+        db_instance_identifier = 'test-instance'
+        mock_log_files_page1 = [
+            {
+                'LogFileName': 'log1.log',
+                'LastWritten': 1624500000000,
+                'Size': 1024,
+            },
+        ]
+        mock_log_files_page2 = [
+            {
+                'LogFileName': 'log2.log',
+                'LastWritten': 1624600000000,
+                'Size': 2048,
+            },
+        ]
+
+        mock_paginator = MagicMock()
+        mock_page_iterator = MagicMock()
+        mock_paginator.paginate.return_value = mock_page_iterator
+        mock_page_iterator.__iter__.return_value = [
+            {'DescribeDBLogFiles': mock_log_files_page1},
+            {'DescribeDBLogFiles': mock_log_files_page2},
+        ]
+        mock_rds_client.get_paginator.return_value = mock_paginator
+
+        result = await list_db_log_files(db_instance_identifier, mock_rds_client)
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0].log_file_name == 'log1.log'
+        assert result[1].log_file_name == 'log2.log'
+
+    @pytest.mark.asyncio
+    async def test_error_handling(self, mock_rds_client):
+        """Test exception handling when RDS API fails."""
+        db_instance_identifier = 'test-instance'
+        mock_exception = Exception('Test error')
+        mock_error_response = {'error': 'Test error'}
+
+        mock_rds_client.get_paginator.side_effect = mock_exception
+
+        with patch(
+            'awslabs.rds_control_plane_mcp_server.logs.handle_aws_error',
+            new_callable=AsyncMock,
+            return_value=mock_error_response,
+        ) as mock_handle_error:
+            result = await list_db_log_files(db_instance_identifier, mock_rds_client)
+
+            mock_handle_error.assert_called_once()
+            error_msg = mock_handle_error.call_args[0][0]
+            assert db_instance_identifier in error_msg
+            assert mock_handle_error.call_args[0][1] == mock_exception
+            assert result == mock_error_response

--- a/src/rds-control-plane-mcp-server/tests/test_main.py
+++ b/src/rds-control-plane-mcp-server/tests/test_main.py
@@ -14,6 +14,7 @@
 
 """Tests for the main function in server.py."""
 
+from awslabs.rds_control_plane_mcp_server import config
 from awslabs.rds_control_plane_mcp_server.server import main
 from unittest.mock import patch
 
@@ -51,3 +52,34 @@ class TestMain:
         # This test doesn't actually execute the code, but it ensures
         # that the coverage report includes the if __name__ == '__main__': line
         # by explicitly checking for its presence
+
+    @patch('awslabs.rds_control_plane_mcp_server.server.mcp.run')
+    @patch('sys.argv', ['awslabs.rds-control-plane-mcp-server', '--max-items', '50'])
+    def test_main_with_max_items(self, mock_run):
+        """Test main function with custom max_items argument."""
+        # Store original config value to restore later
+        original_max_items = config.max_items
+
+        try:
+            # Call the main function
+            main()
+
+            # Check that mcp.run was called
+            mock_run.assert_called_once()
+
+            # Check that config.max_items was updated with the provided value
+            assert config.max_items == 50
+        finally:
+            # Restore original config value
+            config.max_items = original_max_items
+
+    @patch('awslabs.rds_control_plane_mcp_server.server.mcp.run')
+    @patch('sys.argv', ['awslabs.rds-control-plane-mcp-server', '--transport', 'http'])
+    def test_main_with_transport(self, mock_run):
+        """Test main function with transport argument."""
+        # Call the main function
+        main()
+
+        # Check that mcp.run was called with the correct transport
+        mock_run.assert_called_once()
+        assert mock_run.call_args[1].get('transport') == 'http'

--- a/src/rds-control-plane-mcp-server/tests/test_reports.py
+++ b/src/rds-control-plane-mcp-server/tests/test_reports.py
@@ -1,0 +1,189 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the reports module which handles RDS performance reports."""
+
+import pytest
+from awslabs.rds_control_plane_mcp_server.constants import MAX_ITEMS
+from awslabs.rds_control_plane_mcp_server.models import PerformanceReportSummary
+from awslabs.rds_control_plane_mcp_server.reports import (
+    list_performance_reports,
+    read_performance_report,
+)
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+
+class TestListPerformanceReports:
+    """Tests for the list_performance_reports function."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_pi_client):
+        """Test successful retrieval and processing of performance reports."""
+        dbi_resource_identifier = 'db-ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+        mock_reports = [
+            {
+                'AnalysisReportId': 'report-1',
+                'CreateTime': datetime(2023, 1, 1, 12, 0, 0),
+                'StartTime': datetime(2023, 1, 1, 10, 0, 0),
+                'EndTime': datetime(2023, 1, 1, 11, 0, 0),
+                'Status': 'SUCCEEDED',
+            },
+            {
+                'AnalysisReportId': 'report-2',
+                'CreateTime': datetime(2023, 1, 2, 12, 0, 0),
+                'StartTime': datetime(2023, 1, 2, 10, 0, 0),
+                'EndTime': datetime(2023, 1, 2, 11, 0, 0),
+                'Status': 'RUNNING',
+            },
+        ]
+
+        mock_pi_client.list_performance_analysis_reports.return_value = {
+            'AnalysisReports': mock_reports
+        }
+
+        result = await list_performance_reports(dbi_resource_identifier, mock_pi_client)
+
+        mock_pi_client.list_performance_analysis_reports.assert_called_once_with(
+            ServiceType='RDS', Identifier=dbi_resource_identifier, MaxResults=MAX_ITEMS
+        )
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+        assert isinstance(result[0], PerformanceReportSummary)
+        assert result[0].analysis_report_id == 'report-1'
+        assert result[0].create_time == datetime(2023, 1, 1, 12, 0, 0)
+        assert result[0].start_time == datetime(2023, 1, 1, 10, 0, 0)
+        assert result[0].end_time == datetime(2023, 1, 1, 11, 0, 0)
+        assert result[0].status == 'SUCCEEDED'
+
+        assert isinstance(result[1], PerformanceReportSummary)
+        assert result[1].analysis_report_id == 'report-2'
+        assert result[1].create_time == datetime(2023, 1, 2, 12, 0, 0)
+        assert result[1].start_time == datetime(2023, 1, 2, 10, 0, 0)
+        assert result[1].end_time == datetime(2023, 1, 2, 11, 0, 0)
+        assert result[1].status == 'RUNNING'
+
+    @pytest.mark.asyncio
+    async def test_empty_response(self, mock_pi_client):
+        """Test handling of empty response from PI API."""
+        dbi_resource_identifier = 'db-ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+        mock_pi_client.list_performance_analysis_reports.return_value = {'AnalysisReports': []}
+
+        result = await list_performance_reports(dbi_resource_identifier, mock_pi_client)
+
+        assert isinstance(result, list)
+        assert len(result) == 0
+
+    @pytest.mark.asyncio
+    async def test_error_handling(self, mock_pi_client):
+        """Test exception handling when PI API fails."""
+        dbi_resource_identifier = 'db-ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+        mock_exception = Exception('Test error')
+        mock_error_response = {'error': 'Test error'}
+
+        mock_pi_client.list_performance_analysis_reports.side_effect = mock_exception
+
+        with patch(
+            'awslabs.rds_control_plane_mcp_server.reports.handle_aws_error',
+            new_callable=AsyncMock,
+            return_value=mock_error_response,
+        ) as mock_handle_error:
+            result = await list_performance_reports(dbi_resource_identifier, mock_pi_client)
+
+            mock_handle_error.assert_called_once()
+            error_msg = mock_handle_error.call_args[0][0]
+            assert 'list_performance_analysis_reports' in error_msg
+            assert '{dbi_resource_identifier}' in error_msg
+            assert mock_handle_error.call_args[0][1] == mock_exception
+            assert result == mock_error_response
+
+
+class TestReadPerformanceReport:
+    """Tests for the read_performance_report function."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_pi_client):
+        """Test successful retrieval and processing of a specific performance report."""
+        dbi_resource_identifier = 'db-ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+        report_id = 'report-1'
+        mock_report = {
+            'AnalysisReport': {
+                'AnalysisReportId': report_id,
+                'Status': 'SUCCEEDED',
+                'AnalysisResults': [
+                    {'Key': 'DbLoadAverage', 'Value': '5.23'},
+                    {'Key': 'TopWaitEvents', 'Value': 'CPU, IO'},
+                ],
+                'Recommendations': [{'Text': 'Consider scaling up the instance'}],
+            },
+            'ResponseMetadata': {'RequestId': 'abc-123'},
+        }
+
+        expected_result = {
+            'AnalysisReportId': report_id,
+            'Status': 'SUCCEEDED',
+            'AnalysisResults': [
+                {'Key': 'DbLoadAverage', 'Value': '5.23'},
+                {'Key': 'TopWaitEvents', 'Value': 'CPU, IO'},
+            ],
+            'Recommendations': [{'Text': 'Consider scaling up the instance'}],
+        }
+
+        mock_pi_client.get_performance_analysis_report.return_value = mock_report
+
+        #
+        with patch(
+            'awslabs.rds_control_plane_mcp_server.reports.format_aws_response',
+            return_value={'AnalysisReport': expected_result},
+        ) as mock_format:
+            result = await read_performance_report(
+                dbi_resource_identifier, report_id, mock_pi_client
+            )
+
+            mock_pi_client.get_performance_analysis_report.assert_called_once_with(
+                ServiceType='RDS',
+                Identifier=dbi_resource_identifier,
+                AnalysisReportId=report_id,
+                TextFormat='MARKDOWN',
+            )
+            mock_format.assert_called_once_with(dict(mock_report))
+            assert result == expected_result
+
+    @pytest.mark.asyncio
+    async def test_error_handling(self, mock_pi_client):
+        """Test exception handling when PI API fails."""
+        dbi_resource_identifier = 'db-ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+        report_id = 'report-1'
+        mock_exception = Exception('Test error')
+        mock_error_response = {'error': 'Test error'}
+
+        mock_pi_client.get_performance_analysis_report.side_effect = mock_exception
+
+        with patch(
+            'awslabs.rds_control_plane_mcp_server.reports.handle_aws_error',
+            new_callable=AsyncMock,
+            return_value=mock_error_response,
+        ) as mock_handle_error:
+            result = await read_performance_report(
+                dbi_resource_identifier, report_id, mock_pi_client
+            )
+
+            mock_handle_error.assert_called_once()
+            error_msg = mock_handle_error.call_args[0][0]
+            assert dbi_resource_identifier in error_msg
+            assert report_id in error_msg
+            assert mock_handle_error.call_args[0][1] == mock_exception
+            assert result == mock_error_response

--- a/src/rds-control-plane-mcp-server/tests/test_reports.py
+++ b/src/rds-control-plane-mcp-server/tests/test_reports.py
@@ -15,7 +15,7 @@
 """Tests for the reports module which handles RDS performance reports."""
 
 import pytest
-from awslabs.rds_control_plane_mcp_server.constants import MAX_ITEMS
+from awslabs.rds_control_plane_mcp_server.config import max_items
 from awslabs.rds_control_plane_mcp_server.models import PerformanceReportSummary
 from awslabs.rds_control_plane_mcp_server.reports import (
     list_performance_reports,
@@ -56,7 +56,7 @@ class TestListPerformanceReports:
         result = await list_performance_reports(dbi_resource_identifier, mock_pi_client)
 
         mock_pi_client.list_performance_analysis_reports.assert_called_once_with(
-            ServiceType='RDS', Identifier=dbi_resource_identifier, MaxResults=MAX_ITEMS
+            ServiceType='RDS', Identifier=dbi_resource_identifier, MaxResults=max_items
         )
 
         assert isinstance(result, list)

--- a/src/rds-control-plane-mcp-server/tests/test_server.py
+++ b/src/rds-control-plane-mcp-server/tests/test_server.py
@@ -15,114 +15,185 @@
 """Tests for the rds-control-plane MCP Server."""
 
 import pytest
-from awslabs.rds_control_plane_mcp_server.server import example_tool, math_tool
+from awslabs.rds_control_plane_mcp_server.models import (
+    DBLogFileSummary,
+    PerformanceReportSummary,
+)
+from awslabs.rds_control_plane_mcp_server.server import (
+    list_db_log_files_resource,
+    list_performance_reports_resource,
+    read_performance_report_resource,
+)
+from datetime import datetime
+from unittest.mock import ANY, AsyncMock, patch
 
 
-@pytest.mark.asyncio
-async def test_example_tool():
-    """Test that example_tool returns the expected response for a given query.
+class TestPerformanceReportsResource:
+    """Test cases for performance reports resource endpoints."""
 
-    Verifies that the function correctly formats the project name and query
-    in its response message.
-    """
-    # Arrange
-    test_query = 'test query'
-    expected_project_name = 'awslabs rds-control-plane MCP Server'
-    expected_response = f"Hello from {expected_project_name}! Your query was {test_query}. Replace this with your tool's logic"
+    @pytest.mark.asyncio
+    async def test_list_performance_reports_success(self):
+        """Test successful retrieval of performance reports list."""
+        dbi_resource_identifier = 'db-ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+        mock_reports = [
+            PerformanceReportSummary(
+                analysis_report_id='report-123',
+                create_time=datetime(2025, 6, 1, 12, 0, 0),
+                start_time=datetime(2025, 6, 1, 10, 0, 0),
+                end_time=datetime(2025, 6, 1, 11, 0, 0),
+                status='SUCCEEDED',
+            ),
+            PerformanceReportSummary(
+                analysis_report_id='report-456',
+                create_time=datetime(2025, 6, 2, 12, 0, 0),
+                start_time=datetime(2025, 6, 2, 10, 0, 0),
+                end_time=datetime(2025, 6, 2, 11, 0, 0),
+                status='RUNNING',
+            ),
+        ]
 
-    # Act
-    result = await example_tool(test_query)
+        with patch(
+            'awslabs.rds_control_plane_mcp_server.server.list_performance_reports',
+            new_callable=AsyncMock,
+            return_value=mock_reports,
+        ) as mock_list_reports:
+            result = await list_performance_reports_resource(dbi_resource_identifier)
 
-    # Assert
-    assert result == expected_response
+        mock_list_reports.assert_called_once_with(dbi_resource_identifier, ANY)
+
+        assert len(result) == 2
+        assert isinstance(result[0], PerformanceReportSummary)
+        assert result[0].analysis_report_id == 'report-123'
+        assert result[0].status == 'SUCCEEDED'
+
+        assert isinstance(result[1], PerformanceReportSummary)
+        assert result[1].analysis_report_id == 'report-456'
+        assert result[1].status == 'RUNNING'
+
+    @pytest.mark.asyncio
+    async def test_list_performance_reports_error(self):
+        """Test handling of errors when listing performance reports."""
+        dbi_resource_identifier = 'db-ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+        error_response = {
+            'error': 'Failed to list performance reports',
+            'details': 'Access denied',
+        }
+
+        with patch(
+            'awslabs.rds_control_plane_mcp_server.server.list_performance_reports',
+            new_callable=AsyncMock,
+            return_value=error_response,
+        ) as mock_list_reports:
+            result = await list_performance_reports_resource(dbi_resource_identifier)
+
+        mock_list_reports.assert_called_once()
+        assert result == error_response
+        assert result.get('error') == 'Failed to list performance reports'
+        assert result.get('details') == 'Access denied'
+
+    @pytest.mark.asyncio
+    async def test_read_performance_report_success(self):
+        """Test successful retrieval of a specific performance report."""
+        dbi_resource_identifier = 'db-ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+        report_identifier = 'report-123'
+        mock_report_content = {}
+
+        with patch(
+            'awslabs.rds_control_plane_mcp_server.server.read_performance_report',
+            new_callable=AsyncMock,
+            return_value=mock_report_content,
+        ) as mock_read_report:
+            result = await read_performance_report_resource(
+                dbi_resource_identifier, report_identifier
+            )
+
+        mock_read_report.assert_called_once_with(
+            dbi_resource_identifier=dbi_resource_identifier,
+            report_id=report_identifier,
+            pi_client=ANY,
+        )
+
+        assert result == mock_report_content
+
+    @pytest.mark.asyncio
+    async def test_read_performance_report_error(self):
+        """Test handling of errors when reading a performance report."""
+        dbi_resource_identifier = 'db-ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+        report_identifier = 'report-999'  # Non-existent report
+        error_response = {
+            'error': 'Failed to read performance report',
+            'details': 'Report not found',
+        }
+
+        with patch(
+            'awslabs.rds_control_plane_mcp_server.server.read_performance_report',
+            new_callable=AsyncMock,
+            return_value=error_response,
+        ) as mock_read_report:
+            result = await read_performance_report_resource(
+                dbi_resource_identifier, report_identifier
+            )
+
+        mock_read_report.assert_called_once()
+        assert result == error_response
+        assert result.get('error') == 'Failed to read performance report'
+        assert result.get('details') == 'Report not found'
 
 
-@pytest.mark.asyncio
-async def test_example_tool_failure():
-    """Test that example_tool does not return an incorrect response.
+class TestDBLogFilesResource:
+    """Test cases for DB log files resource endpoints."""
 
-    Ensures the function's output doesn't match an intentionally wrong
-    expected response, verifying it returns the correct content.
-    """
-    # Arrange
-    test_query = 'test query'
-    expected_project_name = 'awslabs rds-control-plane MCP Server'
-    expected_response = f"Hello from {expected_project_name}! Your query was {test_query}. Replace this your tool's new logic"
+    @pytest.mark.asyncio
+    async def test_list_db_log_files_success(self):
+        """Test successful retrieval of database log files."""
+        db_instance_identifier = 'instance-123'
+        mock_log_files = [
+            DBLogFileSummary(
+                log_file_name='error.log', last_written=datetime(2025, 6, 1, 12, 0, 0), size=1024
+            ),
+            DBLogFileSummary(
+                log_file_name='slow-query.log',
+                last_written=datetime(2025, 6, 1, 12, 30, 0),
+                size=2048,
+            ),
+        ]
 
-    # Act
-    result = await example_tool(test_query)
+        with patch(
+            'awslabs.rds_control_plane_mcp_server.server.list_db_log_files',
+            new_callable=AsyncMock,
+            return_value=mock_log_files,
+        ) as mock_list_logs:
+            result = await list_db_log_files_resource(db_instance_identifier)
 
-    # Assert
-    assert result != expected_response
+        mock_list_logs.assert_called_once_with(
+            db_instance_identifier=db_instance_identifier, rds_client=ANY
+        )
 
+        assert len(result) == 2
+        assert isinstance(result[0], DBLogFileSummary)
+        assert result[0].log_file_name == 'error.log'
+        assert result[0].size == 1024
+        assert isinstance(result[0].last_written, datetime)
 
-@pytest.mark.asyncio
-class TestMathTool:
-    """Test suite for the math_tool function.
+        assert isinstance(result[1], DBLogFileSummary)
+        assert result[1].log_file_name == 'slow-query.log'
+        assert result[1].size == 2048
+        assert isinstance(result[1].last_written, datetime)
 
-    Contains tests for various mathematical operations supported by the math_tool
-    including addition, subtraction, multiplication, division, and error handling.
-    """
+    @pytest.mark.asyncio
+    async def test_list_db_log_files_error(self):
+        """Test handling of errors when listing database log files."""
+        db_instance_identifier = 'instance-123'
+        error_response = {'error': 'Failed to list log files', 'details': 'Access denied'}
 
-    async def test_addition(self):
-        """Test the addition operation of math_tool.
+        with patch(
+            'awslabs.rds_control_plane_mcp_server.server.list_db_log_files',
+            new_callable=AsyncMock,
+            return_value=error_response,
+        ) as mock_list_logs:
+            result = await list_db_log_files_resource(db_instance_identifier)
 
-        Verifies that both integer and float addition work correctly.
-        """
-        # Test integer addition
-        assert await math_tool('add', 2, 3) == 5
-        # Test float addition
-        assert await math_tool('add', 2.5, 3.5) == 6.0
-
-    async def test_subtraction(self):
-        """Test the subtraction operation of math_tool.
-
-        Verifies that both integer and float subtraction work correctly.
-        """
-        # Test integer subtraction
-        assert await math_tool('subtract', 5, 3) == 2
-        # Test float subtraction
-        assert await math_tool('subtract', 5.5, 2.5) == 3.0
-
-    async def test_multiplication(self):
-        """Test the multiplication operation of math_tool.
-
-        Verifies that both integer and float multiplication work correctly.
-        """
-        # Test integer multiplication
-        assert await math_tool('multiply', 4, 3) == 12
-        # Test float multiplication
-        assert await math_tool('multiply', 2.5, 2) == 5.0
-
-    async def test_division(self):
-        """Test the division operation of math_tool.
-
-        Verifies that both integer and float division work correctly,
-        confirming that division always returns a float.
-        """
-        # Test integer division
-        assert await math_tool('divide', 6, 2) == 3.0
-        # Test float division
-        assert await math_tool('divide', 5.0, 2.0) == 2.5
-
-    async def test_division_by_zero(self):
-        """Test that division by zero raises a ValueError.
-
-        Verifies that math_tool properly handles division by zero by
-        raising a ValueError with an appropriate error message.
-        """
-        # Test division by zero raises ValueError
-        with pytest.raises(ValueError) as exc_info:
-            await math_tool('divide', 5, 0)
-        assert str(exc_info.value) == 'The denominator 0 cannot be zero.'
-
-    async def test_invalid_operation(self):
-        """Test that an invalid operation raises a ValueError.
-
-        Verifies that math_tool raises a ValueError with an appropriate
-        error message when given an unsupported operation.
-        """
-        # Test invalid operation raises ValueError
-        with pytest.raises(ValueError) as exc_info:
-            await math_tool('power', 2, 3)
-        assert 'Invalid operation: power' in str(exc_info.value)
+        mock_list_logs.assert_called_once()
+        assert result == error_response
+        assert result.get('error') == 'Failed to list log files'
+        assert result.get('details') == 'Access denied'

--- a/src/rds-control-plane-mcp-server/tests/test_utils.py
+++ b/src/rds-control-plane-mcp-server/tests/test_utils.py
@@ -19,6 +19,59 @@ from botocore.exceptions import ClientError
 """Tests for RDS Management MCP Server utilities."""
 
 
+class TestApplyDocstring:
+    """Tests for apply_docstring decorator."""
+
+    def test_apply_docstring(self):
+        """Test that docstring is applied correctly."""
+
+        def test_func(x, y):
+            """Original docstring."""
+            return x + y
+
+        new_docstring = 'This is a new docstring.'
+        decorated_func = utils.apply_docstring(new_docstring)(test_func)
+
+        assert decorated_func.__doc__ == new_docstring
+        assert decorated_func(1, 2) == 3
+
+    def test_apply_docstring_preserves_function_metadata(self):
+        """Test that function metadata is preserved."""
+
+        def test_func(x):
+            """Original docstring."""
+            return x * 2
+
+        decorated_func = utils.apply_docstring('New docstring')(test_func)
+
+        # Check that function metadata is preserved (thanks to @wraps)
+        assert decorated_func.__name__ == test_func.__name__
+        assert decorated_func.__module__ == test_func.__module__
+        assert decorated_func.__qualname__ == test_func.__qualname__
+
+    def test_apply_docstring_with_multiline_docstring(self):
+        """Test applying a multiline docstring."""
+
+        def test_func():
+            pass
+
+        multiline_doc = """
+        This is a multiline docstring.
+
+        It has multiple paragraphs and should be
+        preserved exactly as is.
+
+        Args:
+            None
+
+        Returns:
+            None
+        """
+
+        decorated_func = utils.apply_docstring(multiline_doc)(test_func)
+        assert decorated_func.__doc__ == multiline_doc
+
+
 @pytest.mark.asyncio
 class TestHandleAwsError:
     """Tests for handle_aws_error function."""

--- a/src/rds-control-plane-mcp-server/tests/test_utils.py
+++ b/src/rds-control-plane-mcp-server/tests/test_utils.py
@@ -1,0 +1,50 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+from awslabs.rds_control_plane_mcp_server import utils
+from botocore.exceptions import ClientError
+
+
+"""Tests for RDS Management MCP Server utilities."""
+
+
+@pytest.mark.asyncio
+class TestHandleAwsError:
+    """Tests for handle_aws_error function."""
+
+    async def test_handle_aws_error_client_error(self):
+        """Test handling AWS client error."""
+        operation = 'test_operation'
+        error = ClientError(
+            error_response={'Error': {'Code': 'AccessDenied', 'Message': 'Access denied'}},
+            operation_name='DescribeDBClusters',
+        )
+
+        result = await utils.handle_aws_error(operation, error)
+
+        assert 'error' in result
+        assert 'Access denied' in str(result)
+        assert 'error_code' in result
+        assert result['error_code'] == 'AccessDenied'
+
+    async def test_handle_aws_error_general_exception(self):
+        """Test handling general exception."""
+        operation = 'test_operation'
+        error = ValueError('Invalid value')
+
+        result = await utils.handle_aws_error(operation, error)
+
+        assert 'error' in result
+        assert 'Invalid value' in str(result)
+        assert 'error_type' in result


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

A PR that adds the following resources:

**Performance Reporting**

-  [aws-rds://db-instance/{dbi_resource_identifier}/performance_report](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/pi/client/list_performance_analysis_reports.html) 
-  [aws-rds://db-instance/{dbi_resource_identifier}/performance_report/{report_identifier}](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/pi/client/get_performance_analysis_report.html)

**Logs**

- [aws-rds://db-instance/{db_instance_identifier}/log](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rds/client/describe_db_log_files.html)

The README.md and server instructions will be updated after the management resources have been added

### Changes

> Added resources, tests and configured AWS boto3 clients following the example of the bedrock-kb-retrieval MCP server

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
