### PR TITLE
feature/add cluster instance resources

### DIFF
--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/constants.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/constants.py
@@ -1,0 +1,56 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Constants for RDS Control Plane MCP Server."""
+
+# MCP Server Version
+MCP_SERVER_VERSION = '0.1.0'
+
+# Error Messages
+ERROR_READONLY_MODE = 'This operation requires write access. The server is currently in read-only mode.'
+ERROR_MISSING_PARAMS = 'Missing required parameters: {}'
+ERROR_INVALID_PARAMS = 'Invalid parameters: {}'
+ERROR_AWS_API = 'AWS API error: {}'
+ERROR_UNEXPECTED = 'Unexpected error: {}'
+ERROR_NOT_FOUND = 'Resource not found: {}'
+ERROR_OPERATION_FAILED = 'Operation failed: {}'
+
+# Success Messages
+SUCCESS_CREATED = 'Successfully created {}'
+SUCCESS_MODIFIED = 'Successfully modified {}'
+SUCCESS_DELETED = 'Successfully deleted {}'
+
+# Resource URI Prefixes
+RESOURCE_PREFIX_DB_CLUSTER = 'aws-rds://db-cluster'
+RESOURCE_PREFIX_DB_INSTANCE = 'aws-rds://db-instance'
+
+# AWS RDS Engine Types
+ENGINE_AURORA = 'aurora'
+ENGINE_AURORA_MYSQL = 'aurora-mysql'
+ENGINE_AURORA_POSTGRESQL = 'aurora-postgresql'
+ENGINE_MYSQL = 'mysql'
+ENGINE_POSTGRESQL = 'postgres'
+ENGINE_MARIADB = 'mariadb'
+ENGINE_ORACLE = 'oracle'
+ENGINE_SQLSERVER = 'sqlserver'
+
+# Default Values
+DEFAULT_BACKUP_RETENTION_PERIOD = 7
+DEFAULT_PORT_MYSQL = 3306
+DEFAULT_PORT_POSTGRESQL = 5432
+DEFAULT_PORT_MARIADB = 3306
+DEFAULT_PORT_ORACLE = 1521
+DEFAULT_PORT_SQLSERVER = 1433
+DEFAULT_PORT_AURORA = 3306  # compatible with MySQL
+DEFAULT_PORT_AURORA_POSTGRESQL = 5432  # Aurora PostgreSQL

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources.py
@@ -1,0 +1,280 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Resource implementations for RDS Control Plane MCP Server."""
+
+import asyncio
+import json
+from typing import Any, Dict
+from loguru import logger
+
+from .constants import (
+    ERROR_AWS_API,
+    ERROR_UNEXPECTED,
+    RESOURCE_PREFIX_DB_CLUSTER,
+    RESOURCE_PREFIX_DB_INSTANCE,
+)
+
+
+async def handle_aws_error(operation: str, error: Exception) -> Dict[str, Any]:
+    """Handle AWS API errors consistently.
+    
+    Args:
+        operation: The operation that failed
+        error: The exception that was raised
+        
+    Returns:
+        Error response dictionary
+    """
+    from botocore.exceptions import ClientError
+    
+    if isinstance(error, ClientError):
+        error_code = error.response['Error']['Code']
+        error_message = error.response['Error']['Message']
+        logger.error(f'{operation} failed with AWS error {error_code}: {error_message}')
+        
+        return {
+            'error': ERROR_AWS_API.format(error_code),
+            'error_code': error_code,
+            'error_message': error_message,
+            'operation': operation
+        }
+    else:
+        logger.exception(f'{operation} failed with unexpected error')
+        return {
+            'error': ERROR_UNEXPECTED.format(str(error)),
+            'error_type': type(error).__name__,
+            'error_message': str(error),
+            'operation': operation
+        }
+
+
+def convert_datetime_to_string(obj: Any) -> Any:
+    """Recursively convert datetime objects to ISO format strings.
+    
+    Args:
+        obj: Object to convert
+        
+    Returns:
+        Object with datetime objects converted to strings
+    """
+    import datetime
+    
+    if isinstance(obj, datetime.datetime):
+        return obj.isoformat()
+    elif isinstance(obj, dict):
+        return {k: convert_datetime_to_string(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [convert_datetime_to_string(item) for item in obj]
+    return obj
+
+
+def format_cluster_info(cluster: Dict[str, Any]) -> Dict[str, Any]:
+    """Format cluster information for better readability.
+    
+    Args:
+        cluster: Raw cluster data from AWS
+        
+    Returns:
+        Formatted cluster information
+    """
+    return {
+        'cluster_id': cluster.get('DBClusterIdentifier'),
+        'status': cluster.get('Status'),
+        'engine': cluster.get('Engine'),
+        'engine_version': cluster.get('EngineVersion'),
+        'endpoint': cluster.get('Endpoint'),
+        'reader_endpoint': cluster.get('ReaderEndpoint'),
+        'multi_az': cluster.get('MultiAZ'),
+        'backup_retention': cluster.get('BackupRetentionPeriod'),
+        'preferred_backup_window': cluster.get('PreferredBackupWindow'),
+        'preferred_maintenance_window': cluster.get('PreferredMaintenanceWindow'),
+        'created_time': convert_datetime_to_string(cluster.get('ClusterCreateTime')),
+        'members': [
+            {
+                'instance_id': member.get('DBInstanceIdentifier'),
+                'is_writer': member.get('IsClusterWriter'),
+                'status': member.get('DBClusterParameterGroupStatus')
+            }
+            for member in cluster.get('DBClusterMembers', [])
+        ],
+        'vpc_security_groups': [
+            {
+                'id': sg.get('VpcSecurityGroupId'),
+                'status': sg.get('Status')
+            }
+            for sg in cluster.get('VpcSecurityGroups', [])
+        ],
+        'tags': {tag['Key']: tag['Value'] for tag in cluster.get('TagList', [])}
+    }
+
+
+def format_instance_info(instance: Dict[str, Any]) -> Dict[str, Any]:
+    """Format instance information for better readability.
+    
+    Args:
+        instance: Raw instance data from AWS
+        
+    Returns:
+        Formatted instance information
+    """
+    return {
+        'instance_id': instance.get('DBInstanceIdentifier'),
+        'status': instance.get('DBInstanceStatus'),
+        'engine': instance.get('Engine'),
+        'engine_version': instance.get('EngineVersion'),
+        'instance_class': instance.get('DBInstanceClass'),
+        'endpoint': {
+            'address': instance.get('Endpoint', {}).get('Address'),
+            'port': instance.get('Endpoint', {}).get('Port'),
+            'hosted_zone_id': instance.get('Endpoint', {}).get('HostedZoneId')
+        },
+        'availability_zone': instance.get('AvailabilityZone'),
+        'multi_az': instance.get('MultiAZ'),
+        'storage': {
+            'type': instance.get('StorageType'),
+            'allocated': instance.get('AllocatedStorage'),
+            'encrypted': instance.get('StorageEncrypted')
+        },
+        'preferred_backup_window': instance.get('PreferredBackupWindow'),
+        'preferred_maintenance_window': instance.get('PreferredMaintenanceWindow'),
+        'publicly_accessible': instance.get('PubliclyAccessible'),
+        'vpc_security_groups': [
+            {
+                'id': sg.get('VpcSecurityGroupId'),
+                'status': sg.get('Status')
+            }
+            for sg in instance.get('VpcSecurityGroups', [])
+        ],
+        'db_cluster': instance.get('DBClusterIdentifier'),
+        'tags': {tag['Key']: tag['Value'] for tag in instance.get('TagList', [])}
+    }
+
+
+async def get_cluster_list_resource(rds_client: Any) -> str:
+    """Get list of all RDS clusters as a resource.
+    
+    Args:
+        rds_client: AWS RDS client
+        
+    Returns:
+        JSON string with cluster list
+    """
+    try:
+        logger.info("Getting cluster list resource")
+        response = await asyncio.to_thread(rds_client.describe_db_clusters)
+        
+        clusters = []
+        for cluster in response.get('DBClusters', []):
+            clusters.append(format_cluster_info(cluster))
+        
+        result = {
+            'clusters': clusters,
+            'count': len(clusters),
+            'resource_uri': RESOURCE_PREFIX_DB_CLUSTER,
+        }
+        
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        error_result = await handle_aws_error('get_cluster_list_resource', e)
+        return json.dumps(error_result, indent=2)
+
+
+async def get_cluster_detail_resource(cluster_id: str, rds_client: Any) -> str:
+    """Get detailed information about a specific cluster as a resource.
+    
+    Args:
+        cluster_id: The cluster identifier
+        rds_client: AWS RDS client
+        
+    Returns:
+        JSON string with cluster details
+    """
+    try:
+        logger.info(f"Getting cluster detail resource for {cluster_id}")
+        response = await asyncio.to_thread(
+            rds_client.describe_db_clusters,
+            DBClusterIdentifier=cluster_id
+        )
+        
+        clusters = response.get('DBClusters', [])
+        if not clusters:
+            return json.dumps({'error': f'Cluster {cluster_id} not found'}, indent=2)
+        
+        cluster = format_cluster_info(clusters[0])
+        cluster['resource_uri'] = f'{RESOURCE_PREFIX_DB_CLUSTER}/{cluster_id}'
+        
+        return json.dumps(cluster, indent=2)
+    except Exception as e:
+        error_result = await handle_aws_error(f'get_cluster_detail_resource({cluster_id})', e)
+        return json.dumps(error_result, indent=2)
+
+
+async def get_instance_list_resource(rds_client: Any) -> str:
+    """Get list of all RDS instances as a resource.
+    
+    Args:
+        rds_client: AWS RDS client
+        
+    Returns:
+        JSON string with instance list
+    """
+    try:
+        logger.info("Getting instance list resource")
+        response = await asyncio.to_thread(rds_client.describe_db_instances)
+        
+        instances = []
+        for instance in response.get('DBInstances', []):
+            instances.append(format_instance_info(instance))
+        
+        result = {
+            'instances': instances,
+            'count': len(instances),
+            'resource_uri': RESOURCE_PREFIX_DB_INSTANCE,
+        }
+        
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        error_result = await handle_aws_error('get_instance_list_resource', e)
+        return json.dumps(error_result, indent=2)
+
+
+async def get_instance_detail_resource(instance_id: str, rds_client: Any) -> str:
+    """Get detailed information about a specific instance as a resource.
+    
+    Args:
+        instance_id: The instance identifier
+        rds_client: AWS RDS client
+        
+    Returns:
+        JSON string with instance details
+    """
+    try:
+        logger.info(f"Getting instance detail resource for {instance_id}")
+        response = await asyncio.to_thread(
+            rds_client.describe_db_instances,
+            DBInstanceIdentifier=instance_id
+        )
+        
+        instances = response.get('DBInstances', [])
+        if not instances:
+            return json.dumps({'error': f'Instance {instance_id} not found'}, indent=2)
+        
+        instance = format_instance_info(instances[0])
+        instance['resource_uri'] = f'{RESOURCE_PREFIX_DB_INSTANCE}/{instance_id}'
+        
+        return json.dumps(instance, indent=2)
+    except Exception as e:
+        error_result = await handle_aws_error(f'get_instance_detail_resource({instance_id})', e)
+        return json.dumps(error_result, indent=2)

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/server.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/server.py
@@ -12,91 +12,222 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""awslabs rds-control-plane MCP Server implementation."""
+"""AWS Labs RDS Control Plane MCP Server implementation for Amazon RDS databases."""
 
+import argparse
+import asyncio
+import os
+import sys
+from typing import Any, Dict, List, Optional
+
+import boto3
+from botocore.config import Config
 from loguru import logger
-from mcp.server.fastmcp import FastMCP
-from typing import Literal
+from mcp.server.fastmcp import Context, FastMCP
+
+from .constants import MCP_SERVER_VERSION
+from .resources import (
+    get_cluster_list_resource,
+    get_cluster_detail_resource,
+    get_instance_list_resource,
+    get_instance_detail_resource,
+)
+
+logger.remove()
+logger.add(sys.stderr, level='INFO')
+
+# global variables
+_rds_client = None
+_readonly = True
+_region = None
+
+
+def get_rds_client():
+    """Get or create RDS client."""
+    global _rds_client, _region
+    if _rds_client is None:
+        config = Config(
+            region_name=_region,
+            retries={'max_attempts': 3, 'mode': 'adaptive'},
+        )
+        _rds_client = boto3.client('rds', config=config)
+    return _rds_client
 
 
 mcp = FastMCP(
     'awslabs.rds-control-plane-mcp-server',
-    instructions='Instructions for using this rds-control-plane MCP server. This can be used by clients to improve the LLM'
-    's understanding of available tools, resources, etc. It can be thought of like a '
-    'hint'
-    ' to the model. For example, this information MAY be added to the system prompt. Important to be clear, direct, and detailed.',
-    dependencies=[
-        'pydantic',
-        'loguru',
-    ],
+    version=MCP_SERVER_VERSION,
+    instructions="""This server provides access to Amazon RDS database instances and clusters.
+
+Key capabilities:
+- View detailed information about RDS DB instances
+- View detailed information about RDS DB clusters
+- Access connection endpoints, configuration, and status information
+
+The server operates in read-only mode by default, providing safe access to RDS resources.""",
+    dependencies=['boto3', 'botocore', 'pydantic', 'loguru'],
 )
 
+# ===== RESOURCES =====
+# read-only access to RDS data
 
-@mcp.tool(name='ExampleTool')
-async def example_tool(
-    query: str,
-) -> str:
-    """Example tool implementation.
-
-    Replace this with your own tool implementation.
+@mcp.resource(uri='aws-rds://db-cluster', name='DB Clusters', mime_type='application/json')
+async def list_clusters_resource() -> str:
+    """List all available Amazon RDS clusters in your account.
+    
+    <use_case>
+    Use this resource to discover all available RDS database clusters in your AWS account.
+    </use_case>
+    
+    <important_notes>
+    1. The response provides essential information about each cluster
+    2. Cluster identifiers returned can be used with the db-cluster/{cluster_id} resource
+    3. Clusters are filtered to the AWS region specified in your environment configuration
+    </important_notes>
+    
+    ## Response structure
+    Returns a JSON document containing:
+    - `clusters`: Array of DB cluster objects
+    - `count`: Number of clusters found
+    - `resource_uri`: Base URI for accessing clusters
     """
-    project_name = 'awslabs rds-control-plane MCP Server'
-    return (
-        f"Hello from {project_name}! Your query was {query}. Replace this with your tool's logic"
-    )
+    return await get_cluster_list_resource(get_rds_client())
 
 
-@mcp.tool(name='MathTool')
-async def math_tool(
-    operation: Literal['add', 'subtract', 'multiply', 'divide'],
-    a: int | float,
-    b: int | float,
-) -> int | float:
-    """Math tool implementation.
-
-    This tool supports the following operations:
-    - add
-    - subtract
-    - multiply
-    - divide
-
-    Parameters:
-        operation (Literal["add", "subtract", "multiply", "divide"]): The operation to perform.
-        a (int): The first number.
-        b (int): The second number.
-
-    Returns:
-        The result of the operation.
+@mcp.resource(
+    uri='aws-rds://db-cluster/{cluster_id}',
+    name='DB Cluster Details',
+    mime_type='application/json',
+)
+async def get_cluster_resource(cluster_id: str) -> str:
+    """Get detailed information about a specific Amazon RDS cluster.
+    
+    <use_case>
+    Use this resource to retrieve comprehensive details about a specific RDS database cluster
+    identified by its cluster ID.
+    </use_case>
+    
+    <important_notes>
+    1. The cluster ID must exist in your AWS account and region
+    2. The response contains full configuration details about the specified cluster
+    3. Error responses will be returned if the cluster doesn't exist
+    </important_notes>
+    
+    ## Response structure
+    Returns a JSON document containing detailed cluster information including:
+    - Status, engine type, and version
+    - Endpoints for connection
+    - Backup configuration
+    - Member instances
+    - Security groups
     """
-    match operation:
-        case 'add':
-            return a + b
-        case 'subtract':
-            return a - b
-        case 'multiply':
-            return a * b
-        case 'divide':
-            try:
-                return a / b
-            except ZeroDivisionError:
-                raise ValueError(f'The denominator {b} cannot be zero.')
-        case _:
-            raise ValueError(
-                f'Invalid operation: {operation} (must be one of: add, subtract, multiply, divide)'
-            )
+    return await get_cluster_detail_resource(cluster_id, get_rds_client())
+
+
+@mcp.resource(uri='aws-rds://db-instance', name='DB Instances', mime_type='application/json')
+async def list_instances_resource() -> str:
+    """List all available Amazon RDS instances in your account.
+    
+    <use_case>
+    Use this resource to discover all available RDS database instances in your AWS account.
+    </use_case>
+    
+    <important_notes>
+    1. The response provides essential information about each instance
+    2. Instance identifiers returned can be used with the db-instance/{instance_id} resource
+    3. Instances are filtered to the AWS region specified in your environment configuration
+    </important_notes>
+    
+    ## Response structure
+    Returns a JSON document containing:
+    - `instances`: Array of DB instance objects
+    - `count`: Number of instances found
+    - `resource_uri`: Base URI for accessing instances
+    """
+    return await get_instance_list_resource(get_rds_client())
+
+
+@mcp.resource(
+    uri='aws-rds://db-instance/{instance_id}',
+    name='DB Instance Details',
+    mime_type='application/json',
+)
+async def get_instance_resource(instance_id: str) -> str:
+    """Get detailed information about a specific Amazon RDS instance.
+    
+    <use_case>
+    Use this resource to retrieve comprehensive details about a specific RDS database instance
+    identified by its instance ID.
+    </use_case>
+    
+    <important_notes>
+    1. The instance ID must exist in your AWS account and region
+    2. The response contains full configuration details about the specified instance
+    3. Error responses will be returned if the instance doesn't exist
+    </important_notes>
+    
+    ## Response structure
+    Returns a JSON document containing detailed instance information including:
+    - Status, engine type, and version
+    - Instance class and storage configuration
+    - Endpoint for connection
+    - Availability zone and Multi-AZ setting
+    - Security groups
+    """
+    return await get_instance_detail_resource(instance_id, get_rds_client())
 
 
 def main():
     """Run the MCP server with CLI argument support."""
-    logger.trace('A trace message.')
-    logger.debug('A debug message.')
-    logger.info('An info message.')
-    logger.success('A success message.')
-    logger.warning('A warning message.')
-    logger.error('An error message.')
-    logger.critical('A critical message.')
+    global _readonly, _region
+    
+    parser = argparse.ArgumentParser(
+        description='An AWS Labs MCP server for Amazon RDS control plane operations'
+    )
+    parser.add_argument('--sse', action='store_true', help='Use SSE transport')
+    parser.add_argument('--port', type=int, default=8888, help='Port to run the server on')
+    parser.add_argument(
+        '--region',
+        type=str,
+        required=True,
+        help='AWS region for RDS operations'
+    )
+    parser.add_argument(
+        '--readonly',
+        type=str,
+        default='true',
+        choices=['true', 'false'],
+        help='Whether to run in read-only mode (default: true)'
+    )
+    parser.add_argument(
+        '--profile',
+        type=str,
+        help='AWS profile to use for credentials'
+    )
 
-    mcp.run()
+    args = parser.parse_args()
+
+    # global configuration
+    _readonly = args.readonly.lower() == 'true'
+    _region = args.region
+    
+    # AWS profile if provided
+    if args.profile:
+        os.environ['AWS_PROFILE'] = args.profile
+    
+    # log configuration
+    logger.info(f"Starting RDS Control Plane MCP Server v{MCP_SERVER_VERSION}")
+    logger.info(f"Region: {_region}")
+    logger.info(f"Read-only mode: {_readonly}")
+    if args.profile:
+        logger.info(f"AWS Profile: {args.profile}")
+
+    # run server with appropriate transport
+    if args.sse:
+        mcp.settings.port = args.port
+        mcp.run(transport='sse')
+    else:
+        mcp.run()
 
 
 if __name__ == '__main__':

--- a/src/rds-control-plane-mcp-server/tests/test_init.py
+++ b/src/rds-control-plane-mcp-server/tests/test_init.py
@@ -12,42 +12,55 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the awslabs.rds-control-plane-mcp-server package."""
+"""Basic import tests for the RDS Control Plane MCP Server."""
 
-import importlib
-import re
+import os
+import sys
+import importlib.util
 
 
-class TestInit:
-    """Tests for the __init__.py module."""
+def test_awslabs_package_exists():
+    """Test that the awslabs package exists."""
+    # Define the path to the awslabs package
+    awslabs_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'awslabs'
+    )
+    assert os.path.exists(awslabs_path)
+    assert os.path.isdir(awslabs_path)
 
-    def test_version(self):
-        """Test that __version__ is defined and follows semantic versioning."""
-        # Import the module
-        import awslabs.rds_control_plane_mcp_server
 
-        # Check that __version__ is defined
-        assert hasattr(awslabs.rds_control_plane_mcp_server, '__version__')
+def test_rds_control_plane_mcp_server_package_exists():
+    """Test that the rds_control_plane_mcp_server package exists."""
+    # Define the path to the rds_control_plane_mcp_server package
+    package_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        'awslabs',
+        'rds_control_plane_mcp_server',
+    )
+    assert os.path.exists(package_path)
+    assert os.path.isdir(package_path)
 
-        # Check that __version__ is a string
-        assert isinstance(awslabs.rds_control_plane_mcp_server.__version__, str)
 
-        # Check that __version__ follows semantic versioning (major.minor.patch)
-        version_pattern = r'^\d+\.\d+\.\d+$'
-        assert re.match(version_pattern, awslabs.rds_control_plane_mcp_server.__version__), (
-            f"Version '{awslabs.rds_control_plane_mcp_server.__version__}' does not follow semantic versioning"
-        )
+def test_can_import_server():
+    """Test that the server module can be imported."""
+    # Import the server module
+    try:
+        from awslabs.rds_control_plane_mcp_server import server
+        assert server is not None
+    except ImportError as e:
+        assert False, f"Failed to import server module: {e}"
 
-    def test_module_reload(self):
-        """Test that the module can be reloaded."""
-        # Import the module
-        import awslabs.rds_control_plane_mcp_server
 
-        # Store the original version
-        original_version = awslabs.rds_control_plane_mcp_server.__version__
+def test_server_has_mcp_instance():
+    """Test that the server module has an MCP instance."""
+    # Import the server module
+    from awslabs.rds_control_plane_mcp_server import server
+    assert hasattr(server, 'mcp')
 
-        # Reload the module
-        importlib.reload(awslabs.rds_control_plane_mcp_server)
 
-        # Check that the version is still the same
-        assert awslabs.rds_control_plane_mcp_server.__version__ == original_version
+def test_constants_has_version():
+    """Test that the constants module has a version."""
+    # Import the constants module
+    from awslabs.rds_control_plane_mcp_server.constants import MCP_SERVER_VERSION
+    assert MCP_SERVER_VERSION is not None
+    assert isinstance(MCP_SERVER_VERSION, str)

--- a/src/rds-control-plane-mcp-server/tests/test_main.py
+++ b/src/rds-control-plane-mcp-server/tests/test_main.py
@@ -12,42 +12,78 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the main function in server.py."""
+"""Tests for the main function of the RDS control plane MCP Server."""
 
+import pytest
+from unittest.mock import patch, MagicMock
+import os
+import sys
 from awslabs.rds_control_plane_mcp_server.server import main
-from unittest.mock import patch
+from awslabs.rds_control_plane_mcp_server.constants import MCP_SERVER_VERSION
 
 
-class TestMain:
-    """Tests for the main function."""
+@pytest.fixture
+def mock_fastmcp():
+    """Mock the FastMCP instance used in the server module."""
+    with patch('awslabs.rds_control_plane_mcp_server.server.mcp') as mock_mcp:
+        yield mock_mcp
 
-    @patch('awslabs.rds_control_plane_mcp_server.server.mcp.run')
-    @patch('sys.argv', ['awslabs.rds-control-plane-mcp-server'])
-    def test_main_default(self, mock_run):
-        """Test main function with default arguments."""
-        # Call the main function
+
+@pytest.fixture
+def mock_argparse():
+    """Mock argparse to simulate command line arguments."""
+    with patch('awslabs.rds_control_plane_mcp_server.server.argparse.ArgumentParser', autospec=True) as mock_argparse:
+        mock_parser = MagicMock()
+        mock_argparse.return_value = mock_parser
+        mock_args = MagicMock()
+        mock_args.region = 'us-east-1'
+        mock_args.readonly = 'true'
+        mock_args.profile = None
+        mock_args.sse = False
+        mock_parser.parse_args.return_value = mock_args
+        yield mock_argparse
+
+
+def test_main_standard_run(mock_fastmcp, mock_argparse):
+    """Test that main runs with standard settings."""
+    with patch('awslabs.rds_control_plane_mcp_server.server.logger') as mock_logger:
         main()
 
-        # Check that mcp.run was called with the correct arguments
-        mock_run.assert_called_once()
-        assert mock_run.call_args[1].get('transport') is None
+        mock_logger.info.assert_any_call(f"Starting RDS Control Plane MCP Server v{MCP_SERVER_VERSION}")
+        mock_logger.info.assert_any_call("Region: us-east-1")
+        mock_logger.info.assert_any_call("Read-only mode: True")
+        mock_fastmcp.run.assert_called_once()
 
-    def test_module_execution(self):
-        """Test the module execution when run as __main__."""
-        # This test directly executes the code in the if __name__ == '__main__': block
-        # to ensure coverage of that line
 
-        # Get the source code of the module
-        import inspect
-        from awslabs.rds_control_plane_mcp_server import server
+def test_main_with_sse(mock_fastmcp, mock_argparse):
+    """Test that main runs with SSE transport."""
+    mock_argparse.return_value.parse_args.return_value.sse = True
+    mock_argparse.return_value.parse_args.return_value.port = 8888
 
-        # Get the source code
-        source = inspect.getsource(server)
+    with patch('awslabs.rds_control_plane_mcp_server.server.logger') as mock_logger:
+        main()
 
-        # Check that the module has the if __name__ == '__main__': block
-        assert "if __name__ == '__main__':" in source
-        assert 'main()' in source
+        assert mock_fastmcp.settings.port == 8888
+        mock_fastmcp.run.assert_called_once_with(transport='sse')
 
-        # This test doesn't actually execute the code, but it ensures
-        # that the coverage report includes the if __name__ == '__main__': line
-        # by explicitly checking for its presence
+
+def test_main_with_aws_profile(mock_fastmcp, mock_argparse):
+    """Test that main sets AWS profile if specified."""
+    mock_argparse.return_value.parse_args.return_value.profile = 'test-profile'
+
+    with patch('awslabs.rds_control_plane_mcp_server.server.logger') as mock_logger, \
+         patch.dict(os.environ, {}, clear=True):  # Start with empty environment
+        main()
+
+        assert os.environ.get('AWS_PROFILE') == 'test-profile'
+        mock_logger.info.assert_any_call("AWS Profile: test-profile")
+
+
+def test_main_with_readonly_false(mock_fastmcp, mock_argparse):
+    """Test that main properly handles readonly=false."""
+    mock_argparse.return_value.parse_args.return_value.readonly = 'false'
+
+    with patch('awslabs.rds_control_plane_mcp_server.server.logger') as mock_logger:
+        main()
+
+        mock_logger.info.assert_any_call("Read-only mode: False")

--- a/src/rds-control-plane-mcp-server/tests/test_server.py
+++ b/src/rds-control-plane-mcp-server/tests/test_server.py
@@ -12,117 +12,476 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the rds-control-plane MCP Server."""
+"""Tests for the RDS Control Plane MCP Server resources."""
 
+import asyncio
+import json
 import pytest
-from awslabs.rds_control_plane_mcp_server.server import example_tool, math_tool
+import pytest_asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+import boto3
+
+from awslabs.rds_control_plane_mcp_server.server import (
+    get_cluster_resource,
+    get_instance_resource,
+    list_clusters_resource,
+    list_instances_resource,
+)
+from awslabs.rds_control_plane_mcp_server.resources import (
+    get_cluster_list_resource,
+    get_cluster_detail_resource,
+    get_instance_list_resource,
+    get_instance_detail_resource,
+)
+
+
+@pytest_asyncio.fixture
+async def aws_credentials():
+    """Mocked AWS Credentials for moto."""
+    import os
+    os.environ['AWS_DEFAULT_REGION'] = 'us-east-1'
+
+
+@pytest_asyncio.fixture
+async def rds_client(aws_credentials):
+    """RDS client fixture with mock database setup."""
+    client = MagicMock()
+    
+    client.describe_db_clusters = MagicMock(return_value={
+        'DBClusters': [
+            {
+                'DBClusterIdentifier': 'test-cluster',
+                'Engine': 'aurora-mysql',
+                'Status': 'available',
+                'Endpoint': 'test-cluster.cluster-abc123.us-east-1.rds.amazonaws.com',
+                'ReaderEndpoint': 'test-cluster.cluster-ro-abc123.us-east-1.rds.amazonaws.com',
+                'MultiAZ': True,
+                'BackupRetentionPeriod': 7,
+                'PreferredBackupWindow': '07:00-09:00',
+                'PreferredMaintenanceWindow': 'sun:05:00-sun:06:00',
+                'DBClusterMembers': [
+                    {
+                        'DBInstanceIdentifier': 'test-instance-1',
+                        'IsClusterWriter': True,
+                        'DBClusterParameterGroupStatus': 'in-sync',
+                    }
+                ],
+                'VpcSecurityGroups': [
+                    {
+                        'VpcSecurityGroupId': 'sg-12345',
+                        'Status': 'active',
+                    }
+                ],
+                'TagList': [
+                    {
+                        'Key': 'Environment',
+                        'Value': 'Test',
+                    }
+                ],
+            }
+        ]
+    })
+    
+    client.describe_db_instances = MagicMock(return_value={
+        'DBInstances': [
+            {
+                'DBInstanceIdentifier': 'test-instance-1',
+                'DBClusterIdentifier': 'test-cluster',
+                'Engine': 'aurora-mysql',
+                'EngineVersion': '5.7.12',
+                'DBInstanceClass': 'db.r5.large',
+                'DBInstanceStatus': 'available',
+                'AvailabilityZone': 'us-east-1a',
+                'MultiAZ': False,
+                'PubliclyAccessible': False,
+                'StorageType': 'aurora',
+                'StorageEncrypted': True,
+                'Endpoint': {
+                    'Address': 'test-instance-1.abc123.us-east-1.rds.amazonaws.com',
+                    'Port': 3306,
+                    'HostedZoneId': 'Z2R2ITUGPM61AM',
+                },
+                'TagList': []
+            },
+            {
+                'DBInstanceIdentifier': 'test-instance-2',
+                'Engine': 'mysql',
+                'EngineVersion': '8.0.23',
+                'DBInstanceClass': 'db.t3.medium',
+                'DBInstanceStatus': 'available',
+                'AvailabilityZone': 'us-east-1b',
+                'MultiAZ': False,
+                'PubliclyAccessible': False,
+                'StorageType': 'gp2',
+                'AllocatedStorage': 20,
+                'StorageEncrypted': False,
+                'Endpoint': {
+                    'Address': 'test-instance-2.def456.us-east-1.rds.amazonaws.com',
+                    'Port': 3306,
+                    'HostedZoneId': 'Z2R2ITUGPM61AM',
+                },
+                'TagList': []
+            }
+        ]
+    })
+    
+    yield client
 
 
 @pytest.mark.asyncio
-async def test_example_tool():
-    """Test that example_tool returns the expected response for a given query.
-
-    Verifies that the function correctly formats the project name and query
-    in its response message.
-    """
-    # Arrange
-    test_query = 'test query'
-    expected_project_name = 'awslabs rds-control-plane MCP Server'
-    expected_response = f"Hello from {expected_project_name}! Your query was {test_query}. Replace this with your tool's logic"
-
-    # Act
-    result = await example_tool(test_query)
-
-    # Assert
-    assert result == expected_response
+async def test_get_cluster_list_resource(rds_client):
+    """Test retrieving cluster list resource."""
+    with patch('awslabs.rds_control_plane_mcp_server.resources.asyncio.to_thread') as mock_to_thread:
+        mock_to_thread.return_value = {
+            'DBClusters': [
+                {
+                    'DBClusterIdentifier': 'test-cluster',
+                    'Engine': 'aurora-mysql',
+                    'Status': 'available',
+                    'Endpoint': 'test-cluster.cluster-abc123.us-east-1.rds.amazonaws.com',
+                    'ReaderEndpoint': 'test-cluster.cluster-ro-abc123.us-east-1.rds.amazonaws.com',
+                    'MultiAZ': True,
+                    'BackupRetentionPeriod': 7,
+                    'PreferredBackupWindow': '07:00-09:00',
+                    'PreferredMaintenanceWindow': 'sun:05:00-sun:06:00',
+                    'DBClusterMembers': [
+                        {
+                            'DBInstanceIdentifier': 'test-instance-1',
+                            'IsClusterWriter': True,
+                            'DBClusterParameterGroupStatus': 'in-sync',
+                        }
+                    ],
+                    'VpcSecurityGroups': [
+                        {
+                            'VpcSecurityGroupId': 'sg-12345',
+                            'Status': 'active',
+                        }
+                    ],
+                    'TagList': [
+                        {
+                            'Key': 'Environment',
+                            'Value': 'Test',
+                        }
+                    ],
+                }
+            ]
+        }
+        
+        result = await get_cluster_list_resource(rds_client)
+        
+        # Verify result
+        result_json = json.loads(result)
+        assert result_json['count'] == 1
+        assert result_json['clusters'][0]['cluster_id'] == 'test-cluster'
+        assert result_json['clusters'][0]['engine'] == 'aurora-mysql'
+        assert result_json['resource_uri'] == 'aws-rds://db-cluster'
 
 
 @pytest.mark.asyncio
-async def test_example_tool_failure():
-    """Test that example_tool does not return an incorrect response.
-
-    Ensures the function's output doesn't match an intentionally wrong
-    expected response, verifying it returns the correct content.
-    """
-    # Arrange
-    test_query = 'test query'
-    expected_project_name = 'awslabs rds-control-plane MCP Server'
-    expected_response = f"Hello from {expected_project_name}! Your query was {test_query}. Replace this your tool's new logic"
-
-    # Act
-    result = await example_tool(test_query)
-
-    # Assert
-    assert result != expected_response
+async def test_get_cluster_detail_resource(rds_client):
+    """Test retrieving cluster detail resource."""
+    with patch('awslabs.rds_control_plane_mcp_server.resources.asyncio.to_thread') as mock_to_thread:
+        mock_to_thread.return_value = {
+            'DBClusters': [
+                {
+                    'DBClusterIdentifier': 'test-cluster',
+                    'Engine': 'aurora-mysql',
+                    'EngineVersion': '5.7.12',
+                    'Status': 'available',
+                    'Endpoint': 'test-cluster.cluster-abc123.us-east-1.rds.amazonaws.com',
+                    'ReaderEndpoint': 'test-cluster.cluster-ro-abc123.us-east-1.rds.amazonaws.com',
+                    'MultiAZ': True,
+                    'BackupRetentionPeriod': 7,
+                    'PreferredBackupWindow': '07:00-09:00',
+                    'PreferredMaintenanceWindow': 'sun:05:00-sun:06:00',
+                    'DBClusterMembers': [
+                        {
+                            'DBInstanceIdentifier': 'test-instance-1',
+                            'IsClusterWriter': True,
+                            'DBClusterParameterGroupStatus': 'in-sync',
+                        }
+                    ],
+                    'VpcSecurityGroups': [
+                        {
+                            'VpcSecurityGroupId': 'sg-12345',
+                            'Status': 'active',
+                        }
+                    ],
+                    'TagList': [
+                        {
+                            'Key': 'Environment',
+                            'Value': 'Test',
+                        }
+                    ],
+                }
+            ]
+        }
+        
+        result = await get_cluster_detail_resource('test-cluster', rds_client)
+        
+        result_json = json.loads(result)
+        assert result_json['cluster_id'] == 'test-cluster'
+        assert result_json['engine'] == 'aurora-mysql'
+        assert result_json['engine_version'] == '5.7.12'
+        assert result_json['status'] == 'available'
+        assert result_json['members'][0]['instance_id'] == 'test-instance-1'
+        assert result_json['resource_uri'] == 'aws-rds://db-cluster/test-cluster'
 
 
 @pytest.mark.asyncio
-class TestMathTool:
-    """Test suite for the math_tool function.
+async def test_get_instance_list_resource(rds_client):
+    """Test retrieving instance list resource."""
+    with patch('awslabs.rds_control_plane_mcp_server.resources.asyncio.to_thread') as mock_to_thread:
+        mock_to_thread.return_value = {
+            'DBInstances': [
+                {
+                    'DBInstanceIdentifier': 'test-instance-1',
+                    'DBClusterIdentifier': 'test-cluster',
+                    'Engine': 'aurora-mysql',
+                    'EngineVersion': '5.7.12',
+                    'DBInstanceClass': 'db.r5.large',
+                    'DBInstanceStatus': 'available',
+                    'AvailabilityZone': 'us-east-1a',
+                    'MultiAZ': False,
+                    'PubliclyAccessible': False,
+                    'StorageType': 'aurora',
+                    'StorageEncrypted': True,
+                    'Endpoint': {
+                        'Address': 'test-instance-1.abc123.us-east-1.rds.amazonaws.com',
+                        'Port': 3306,
+                        'HostedZoneId': 'Z2R2ITUGPM61AM',
+                    },
+                    'VpcSecurityGroups': [
+                        {
+                            'VpcSecurityGroupId': 'sg-12345',
+                            'Status': 'active',
+                        }
+                    ],
+                    'TagList': [
+                        {
+                            'Key': 'Environment',
+                            'Value': 'Test',
+                        }
+                    ],
+                },
+                {
+                    'DBInstanceIdentifier': 'test-instance-2',
+                    'Engine': 'mysql',
+                    'EngineVersion': '8.0.23',
+                    'DBInstanceClass': 'db.t3.medium',
+                    'DBInstanceStatus': 'available',
+                    'AvailabilityZone': 'us-east-1b',
+                    'MultiAZ': False,
+                    'PubliclyAccessible': False,
+                    'StorageType': 'gp2',
+                    'AllocatedStorage': 20,
+                    'StorageEncrypted': False,
+                    'Endpoint': {
+                        'Address': 'test-instance-2.def456.us-east-1.rds.amazonaws.com',
+                        'Port': 3306,
+                        'HostedZoneId': 'Z2R2ITUGPM61AM',
+                    },
+                    'VpcSecurityGroups': [
+                        {
+                            'VpcSecurityGroupId': 'sg-67890',
+                            'Status': 'active',
+                        }
+                    ],
+                    'TagList': [
+                        {
+                            'Key': 'Environment',
+                            'Value': 'Development',
+                        }
+                    ],
+                },
+            ]
+        }
+        
+        result = await get_instance_list_resource(rds_client)
+        
+        result_json = json.loads(result)
+        assert result_json['count'] == 2
+        assert result_json['instances'][0]['instance_id'] == 'test-instance-1'
+        assert result_json['instances'][1]['instance_id'] == 'test-instance-2'
+        assert result_json['instances'][0]['db_cluster'] == 'test-cluster'
+        assert result_json['instances'][1]['db_cluster'] is None
+        assert result_json['resource_uri'] == 'aws-rds://db-instance'
 
-    Contains tests for various mathematical operations supported by the math_tool
-    including addition, subtraction, multiplication, division, and error handling.
-    """
 
-    async def test_addition(self):
-        """Test the addition operation of math_tool.
+@pytest.mark.asyncio
+async def test_get_instance_detail_resource(rds_client):
+    """Test retrieving instance detail resource."""
+    with patch('awslabs.rds_control_plane_mcp_server.resources.asyncio.to_thread') as mock_to_thread:
+        mock_to_thread.return_value = {
+            'DBInstances': [
+                {
+                    'DBInstanceIdentifier': 'test-instance-1',
+                    'DBClusterIdentifier': 'test-cluster',
+                    'Engine': 'aurora-mysql',
+                    'EngineVersion': '5.7.12',
+                    'DBInstanceClass': 'db.r5.large',
+                    'DBInstanceStatus': 'available',
+                    'AvailabilityZone': 'us-east-1a',
+                    'MultiAZ': False,
+                    'PubliclyAccessible': False,
+                    'StorageType': 'aurora',
+                    'StorageEncrypted': True,
+                    'Endpoint': {
+                        'Address': 'test-instance-1.abc123.us-east-1.rds.amazonaws.com',
+                        'Port': 3306,
+                        'HostedZoneId': 'Z2R2ITUGPM61AM',
+                    },
+                    'PreferredBackupWindow': '07:00-09:00',
+                    'PreferredMaintenanceWindow': 'sun:05:00-sun:06:00',
+                    'VpcSecurityGroups': [
+                        {
+                            'VpcSecurityGroupId': 'sg-12345',
+                            'Status': 'active',
+                        }
+                    ],
+                    'TagList': [
+                        {
+                            'Key': 'Environment',
+                            'Value': 'Test',
+                        }
+                    ],
+                }
+            ]
+        }
+        
+        result = await get_instance_detail_resource('test-instance-1', rds_client)
+        
+        result_json = json.loads(result)
+        assert result_json['instance_id'] == 'test-instance-1'
+        assert result_json['db_cluster'] == 'test-cluster'
+        assert result_json['engine'] == 'aurora-mysql'
+        assert result_json['storage']['encrypted'] == True
+        assert result_json['endpoint']['address'] == 'test-instance-1.abc123.us-east-1.rds.amazonaws.com'
+        assert result_json['endpoint']['port'] == 3306
+        assert result_json['resource_uri'] == 'aws-rds://db-instance/test-instance-1'
 
-        Verifies that both integer and float addition work correctly.
-        """
-        # Test integer addition
-        assert await math_tool('add', 2, 3) == 5
-        # Test float addition
-        assert await math_tool('add', 2.5, 3.5) == 6.0
 
-    async def test_subtraction(self):
-        """Test the subtraction operation of math_tool.
+@pytest.mark.asyncio
+async def test_list_clusters_resource():
+    """Test the list_clusters_resource function."""
+    with patch('awslabs.rds_control_plane_mcp_server.server.get_rds_client') as mock_get_rds_client, \
+         patch('awslabs.rds_control_plane_mcp_server.server.get_cluster_list_resource') as mock_get_cluster_list:
+        mock_rds_client = MagicMock()
+        mock_get_rds_client.return_value = mock_rds_client
+        mock_get_cluster_list.return_value = json.dumps({
+            'clusters': [{'cluster_id': 'test-cluster'}],
+            'count': 1,
+            'resource_uri': 'aws-rds://db-cluster'
+        })
+        
+        result = await list_clusters_resource()
+        
+        mock_get_rds_client.assert_called_once()
+        mock_get_cluster_list.assert_called_once_with(mock_rds_client)
+        
+        result_json = json.loads(result)
+        assert result_json['count'] == 1
+        assert result_json['clusters'][0]['cluster_id'] == 'test-cluster'
 
-        Verifies that both integer and float subtraction work correctly.
-        """
-        # Test integer subtraction
-        assert await math_tool('subtract', 5, 3) == 2
-        # Test float subtraction
-        assert await math_tool('subtract', 5.5, 2.5) == 3.0
 
-    async def test_multiplication(self):
-        """Test the multiplication operation of math_tool.
+@pytest.mark.asyncio
+async def test_get_cluster_resource():
+    """Test the get_cluster_resource function."""
+    with patch('awslabs.rds_control_plane_mcp_server.server.get_rds_client') as mock_get_rds_client, \
+         patch('awslabs.rds_control_plane_mcp_server.server.get_cluster_detail_resource') as mock_get_cluster_detail:
+        mock_rds_client = MagicMock()
+        mock_get_rds_client.return_value = mock_rds_client
+        mock_get_cluster_detail.return_value = json.dumps({
+            'cluster_id': 'test-cluster',
+            'engine': 'aurora-mysql',
+            'status': 'available',
+            'resource_uri': 'aws-rds://db-cluster/test-cluster'
+        })
+        
+        result = await get_cluster_resource('test-cluster')
+        
+        mock_get_rds_client.assert_called_once()
+        mock_get_cluster_detail.assert_called_once_with('test-cluster', mock_rds_client)
+        
+        result_json = json.loads(result)
+        assert result_json['cluster_id'] == 'test-cluster'
+        assert result_json['resource_uri'] == 'aws-rds://db-cluster/test-cluster'
 
-        Verifies that both integer and float multiplication work correctly.
-        """
-        # Test integer multiplication
-        assert await math_tool('multiply', 4, 3) == 12
-        # Test float multiplication
-        assert await math_tool('multiply', 2.5, 2) == 5.0
 
-    async def test_division(self):
-        """Test the division operation of math_tool.
+@pytest.mark.asyncio
+async def test_list_instances_resource():
+    """Test the list_instances_resource function."""
+    with patch('awslabs.rds_control_plane_mcp_server.server.get_rds_client') as mock_get_rds_client, \
+         patch('awslabs.rds_control_plane_mcp_server.server.get_instance_list_resource') as mock_get_instance_list:
+        mock_rds_client = MagicMock()
+        mock_get_rds_client.return_value = mock_rds_client
+        mock_get_instance_list.return_value = json.dumps({
+            'instances': [
+                {'instance_id': 'test-instance-1'},
+                {'instance_id': 'test-instance-2'}
+            ],
+            'count': 2,
+            'resource_uri': 'aws-rds://db-instance'
+        })
+        
+        result = await list_instances_resource()
+        
+        mock_get_rds_client.assert_called_once()
+        mock_get_instance_list.assert_called_once_with(mock_rds_client)
+        
+        result_json = json.loads(result)
+        assert result_json['count'] == 2
+        assert result_json['instances'][0]['instance_id'] == 'test-instance-1'
+        assert result_json['instances'][1]['instance_id'] == 'test-instance-2'
 
-        Verifies that both integer and float division work correctly,
-        confirming that division always returns a float.
-        """
-        # Test integer division
-        assert await math_tool('divide', 6, 2) == 3.0
-        # Test float division
-        assert await math_tool('divide', 5.0, 2.0) == 2.5
 
-    async def test_division_by_zero(self):
-        """Test that division by zero raises a ValueError.
+@pytest.mark.asyncio
+async def test_get_instance_resource():
+    """Test the get_instance_resource function."""
+    with patch('awslabs.rds_control_plane_mcp_server.server.get_rds_client') as mock_get_rds_client, \
+         patch('awslabs.rds_control_plane_mcp_server.server.get_instance_detail_resource') as mock_get_instance_detail:
+        mock_rds_client = MagicMock()
+        mock_get_rds_client.return_value = mock_rds_client
+        mock_get_instance_detail.return_value = json.dumps({
+            'instance_id': 'test-instance-1',
+            'db_cluster': 'test-cluster',
+            'status': 'available',
+            'resource_uri': 'aws-rds://db-instance/test-instance-1'
+        })
+        
+        result = await get_instance_resource('test-instance-1')
+        
+        mock_get_rds_client.assert_called_once()
+        mock_get_instance_detail.assert_called_once_with('test-instance-1', mock_rds_client)
+        
+        result_json = json.loads(result)
+        assert result_json['instance_id'] == 'test-instance-1'
+        assert result_json['db_cluster'] == 'test-cluster'
+        assert result_json['resource_uri'] == 'aws-rds://db-instance/test-instance-1'
 
-        Verifies that math_tool properly handles division by zero by
-        raising a ValueError with an appropriate error message.
-        """
-        # Test division by zero raises ValueError
-        with pytest.raises(ValueError) as exc_info:
-            await math_tool('divide', 5, 0)
-        assert str(exc_info.value) == 'The denominator 0 cannot be zero.'
 
-    async def test_invalid_operation(self):
-        """Test that an invalid operation raises a ValueError.
+@pytest.mark.asyncio
+async def test_error_handling_in_get_cluster_list_resource():
+    """Test error handling in get_cluster_list_resource function."""
+    mock_rds_client = MagicMock()
+    mock_rds_client.describe_db_clusters = MagicMock(side_effect=Exception("Test error"))
+    
+    with patch('awslabs.rds_control_plane_mcp_server.resources.asyncio.to_thread', side_effect=Exception("Test error")):
+        result = await get_cluster_list_resource(mock_rds_client)
+        
+        result_json = json.loads(result)
+        assert 'error' in result_json
+        assert 'Test error' in result_json['error_message']
 
-        Verifies that math_tool raises a ValueError with an appropriate
-        error message when given an unsupported operation.
-        """
-        # Test invalid operation raises ValueError
-        with pytest.raises(ValueError) as exc_info:
-            await math_tool('power', 2, 3)
-        assert 'Invalid operation: power' in str(exc_info.value)
+
+@pytest.mark.asyncio
+async def test_error_handling_in_get_instance_detail_resource():
+    """Test error handling in get_instance_detail_resource function for non-existent instance."""
+    with patch('awslabs.rds_control_plane_mcp_server.resources.asyncio.to_thread') as mock_to_thread:
+        mock_to_thread.return_value = {'DBInstances': []}
+        
+        result = await get_instance_detail_resource('non-existent-instance', MagicMock())
+        
+        result_json = json.loads(result)
+        assert 'error' in result_json
+        assert 'non-existent-instance' in result_json['error']


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes #N/A

## Summary

### Changes

This PR adds a new RDS Control Plane MCP server that provides read-only access to Amazon RDS database resources through a clean MCP interface. The server implements four key resources:

- `aws-rds://db-cluster` - Lists all available DB clusters with summary information
- `aws-rds://db-cluster/{cluster_id}` - Gets detailed information about a specific DB cluster
- `aws-rds://db-instance` - Lists all available DB instances with summary information
- `aws-rds://db-instance/{instance_id}` - Gets detailed information about a specific DB instance

The implementation follows the established patterns from existing MCP servers, especially the RDS Management MCP server, but focuses specifically on control plane operations. The code includes extensive test coverage (19 tests) for all aspects of the server functionality.

### User experience

**Before:**
Users didn't have a dedicated MCP interface to access RDS control plane information. They had to use the AWS SDK directly or resort to command-line tools to query information about RDS clusters and instances.

**After:**
Users can now leverage the MCP protocol to access RDS control plane data through a consistent interface. This enables:
- Seamless integration with LLM-powered applications that use the MCP protocol
- Discovery and exploration of RDS resources through standardized resource URIs
- Access to well-formatted JSON responses with consistent structures for RDS resources
- Error handling that follows MCP standards across all operations

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**: N/A

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
