### PR TITLE
feat/return model

### DIFF
--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_cluster/get_cluster_detail.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_cluster/get_cluster_detail.py
@@ -19,6 +19,7 @@ import json
 from ...common.connection import RDSConnectionManager
 from ...common.constants import RESOURCE_PREFIX_DB_CLUSTER
 from ...common.decorator import handle_exceptions
+from ...common.models import ClusterModel
 from ...common.server import mcp
 from .utils import format_cluster_info
 from loguru import logger
@@ -66,7 +67,7 @@ async def get_cluster_detail(
     cluster_id: str = Field(
         ..., description='The unique identifier of the RDS DB cluster to retrieve details for'
     ),
-) -> str:
+) -> ClusterModel:
     """Retrieve detailed information about a specific RDS cluster.
 
     This method queries the AWS RDS API for comprehensive information about
@@ -90,11 +91,9 @@ async def get_cluster_detail(
 
     clusters = response.get('DBClusters', [])
     if not clusters:
-        return json.dumps({'error': f'Cluster {cluster_id} not found'}, indent=2)
+        raise ValueError(f'Cluster {cluster_id} not found')
 
     cluster = format_cluster_info(clusters[0])
     cluster.resource_uri = f'{RESOURCE_PREFIX_DB_CLUSTER}/{cluster_id}'
 
-    model_dict = cluster.model_dump()
-
-    return json.dumps(model_dict, indent=2)
+    return cluster

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_cluster/list_clusters.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_cluster/list_clusters.py
@@ -62,7 +62,7 @@ class ClusterListModel(BaseModel):
     mime_type='application/json',
 )
 @handle_exceptions
-async def list_clusters() -> str:
+async def list_clusters() -> ClusterListModel:
     """List all RDS clusters.
 
     Retrieves a complete list of all RDS database clusters in the current AWS region,
@@ -86,5 +86,4 @@ async def list_clusters() -> str:
         clusters=clusters, count=len(clusters), resource_uri=RESOURCE_PREFIX_DB_CLUSTER
     )
 
-    model_dict = result.model_dump()
-    return json.dumps(model_dict, indent=2)
+    return result

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/get_instance_detail.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/get_instance_detail.py
@@ -19,6 +19,7 @@ import json
 from ...common.connection import RDSConnectionManager
 from ...common.constants import RESOURCE_PREFIX_DB_INSTANCE
 from ...common.decorator import handle_exceptions
+from ...common.models import InstanceModel
 from ...common.server import mcp
 from .utils import format_instance_info
 from loguru import logger
@@ -59,7 +60,7 @@ Returns a JSON document containing detailed instance information including:
 @handle_exceptions
 async def get_instance_detail(
     instance_id: str = Field(..., description='The instance identifier'),
-) -> str:
+) -> InstanceModel:
     """Get detailed information about a specific instance as a resource.
 
     Args:
@@ -77,9 +78,9 @@ async def get_instance_detail(
 
     instances = response.get('DBInstances', [])
     if not instances:
-        return json.dumps({'error': f'Instance {instance_id} not found'}, indent=2)
+        raise ValueError(f'Instance {instance_id} not found')
 
     instance = format_instance_info(instances[0])
     instance.resource_uri = f'{RESOURCE_PREFIX_DB_INSTANCE}/{instance_id}'
 
-    return json.dumps(instance.model_dump(), indent=2)
+    return instance

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/list_db_logs.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/list_db_logs.py
@@ -102,7 +102,7 @@ class DBLogFileListModel(BaseModel):
 @handle_exceptions
 async def list_db_log_files(
     db_instance_identifier: str = Field(..., description='The identifier for the DB instance'),
-) -> str:
+) -> DBLogFileListModel:
     """List all non-empty log files for the database.
 
     Args:
@@ -139,8 +139,4 @@ async def list_db_log_files(
         resource_uri=RESOURCE_PREFIX_DB_LOG_FILES.format(db_instance_identifier),
     )
 
-    # Convert datetime objects to strings for JSON serialization
-    result_dict = result.model_dump()
-    serializable_dict = convert_datetime_to_string(result_dict)
-
-    return json.dumps(serializable_dict, indent=2)
+    return result

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/list_instances.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/list_instances.py
@@ -52,7 +52,7 @@ Returns a JSON document containing:
     description=LIST_INSTANCES_RESOURCE_DESCRIPTION,
 )
 @handle_exceptions
-async def list_instances() -> str:
+async def list_instances() -> InstanceListModel:
     """Get list of all RDS instances as a resource.
 
     Returns:
@@ -71,4 +71,4 @@ async def list_instances() -> str:
         instances=instances, count=len(instances), resource_uri=RESOURCE_PREFIX_DB_INSTANCE
     )
 
-    return json.dumps(result.model_dump(), indent=2)
+    return result

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/list_performance_reports.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/list_performance_reports.py
@@ -109,7 +109,7 @@ async def list_performance_reports(
         ...,
         description='The resource identifier for the DB instance. This is the DbiResourceId returned by the ListDBInstances resource',
     ),
-) -> str:
+) -> PerformanceReportListModel:
     """Retrieve all performance reports for a given DB instance.
 
     Args:
@@ -160,4 +160,4 @@ async def list_performance_reports(
         count=len(reports),
         resource_uri=RESOURCE_PREFIX_DB_PERFORMANCE_REPORT.format(dbi_resource_identifier),
     )
-    return json.dumps(result.model_dump(), indent=2)
+    return result


### PR DESCRIPTION
- modified resource functions to return typed model objects instead of JSON strings
- removed manual JSON serialization steps (model_dump() + json.dumps())

need to still update `read_performance_report.py` - assign to @jonathan-imanu 
