### PR TITLE
fix/standardize-pagination

### DIFF
--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/common/models.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/common/models.py
@@ -71,14 +71,6 @@ class ClusterModel(BaseModel):
     resource_uri: Optional[str] = Field(None, description='The resource URI for this cluster')
 
 
-class ClusterListModel(BaseModel):
-    """DB cluster list model."""
-
-    clusters: List[ClusterModel] = Field(default_factory=list, description='List of DB clusters')
-    count: int = Field(description='Total number of DB clusters')
-    resource_uri: str = Field(description='The resource URI for the DB clusters')
-
-
 class InstanceEndpoint(BaseModel):
     """DB instance endpoint model."""
 
@@ -138,13 +130,3 @@ class InstanceModel(BaseModel):
         None, description='The AWS Region-unique, immutable identifier for the DB instance'
     )
     resource_uri: Optional[str] = Field(None, description='The resource URI for this instance')
-
-
-class InstanceListModel(BaseModel):
-    """DB instance list model."""
-
-    instances: List[InstanceModel] = Field(
-        default_factory=list, description='List of DB instances'
-    )
-    count: int = Field(description='Total number of DB instances')
-    resource_uri: str = Field(description='The resource URI for the DB instances')

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/context.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/context.py
@@ -61,5 +61,4 @@ class Context:
         """
         return {
             'MaxItems': cls._max_items,
-            'PageSize': 20,
         }

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/main.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/main.py
@@ -18,9 +18,13 @@ import argparse
 from awslabs.rds_control_plane_mcp_server.common.constants import MCP_SERVER_VERSION
 from awslabs.rds_control_plane_mcp_server.common.server import mcp
 from awslabs.rds_control_plane_mcp_server.context import Context
-from awslabs.rds_control_plane_mcp_server.resources import (  # noqa: F401 - imported for side effects to register resources
-    db_cluster,
-    db_instance,
+from awslabs.rds_control_plane_mcp_server.resources.db_cluster import get_cluster_detail, list_clusters
+from awslabs.rds_control_plane_mcp_server.resources.db_instance import (
+    get_instance_detail, 
+    list_instances,
+    list_performance_reports,
+    read_performance_report,
+    list_db_log_files
 )
 from loguru import logger
 

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_cluster/get_cluster_detail.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_cluster/get_cluster_detail.py
@@ -90,7 +90,7 @@ async def get_cluster_detail(
     clusters = response.get('DBClusters', [])
     if not clusters:
         raise ValueError(f'Cluster {cluster_id} not found')
-    cluster = format_cluster_info(clusters[0])
+    cluster = format_cluster_detail(clusters[0])
     cluster.resource_uri = 'aws-rds://db-cluster/{cluster_id}'
 
     return cluster

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_cluster/get_cluster_detail.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_cluster/get_cluster_detail.py
@@ -91,6 +91,6 @@ async def get_cluster_detail(
     if not clusters:
         raise ValueError(f'Cluster {cluster_id} not found')
     cluster = format_cluster_detail(clusters[0])
-    cluster.resource_uri = 'aws-rds://db-cluster/{cluster_id}'
+    cluster.resource_uri = f'aws-rds://db-cluster/{cluster_id}'
 
     return cluster

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_cluster/list_clusters.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_cluster/list_clusters.py
@@ -16,10 +16,9 @@
 
 from ...common.connection import RDSConnectionManager
 from ...common.decorator import handle_exceptions
-from ...common.models import ClusterModel
 from ...common.server import mcp
-from ...common.utils import paginate_aws_api_call
-from .utils import format_cluster_summary, ClusterSummaryModel
+from ...common.utils import handle_paginated_aws_api_call
+from .utils import ClusterSummaryModel, format_cluster_summary
 from loguru import logger
 from pydantic import BaseModel, Field
 from typing import List
@@ -48,7 +47,9 @@ Returns a JSON document containing:
 class ClusterListModel(BaseModel):
     """DB cluster list model."""
 
-    clusters: List[ClusterSummaryModel] = Field(default_factory=list, description='List of DB clusters')
+    clusters: List[ClusterSummaryModel] = Field(
+        default_factory=list, description='List of DB clusters'
+    )
     count: int = Field(description='Total number of DB clusters')
     resource_uri: str = Field(description='The resource URI for the DB clusters')
 
@@ -74,10 +75,12 @@ async def list_clusters() -> ClusterListModel:
     logger.info('Listing RDS clusters')
     rds_client = RDSConnectionManager.get_connection()
 
-    clusters = await paginate_aws_api_call(
-        client_function=rds_client.describe_db_clusters,
+    clusters = handle_paginated_aws_api_call(
+        client=rds_client,
+        paginator_name='describe_db_clusters',
+        operation_parameters={},
         format_function=format_cluster_summary,
-        result_key='DBClusters'
+        result_key='DBClusters',
     )
 
     result = ClusterListModel(

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/get_instance_detail.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/get_instance_detail.py
@@ -90,7 +90,7 @@ async def get_instance_detail(
     if not instances:
         raise ValueError(f'Instance {instance_id} not found')
 
-    instance = format_instance_info(instances[0])
+    instance = format_instance_detail(instances[0])
     instance.resource_uri = 'aws-rds://db-instance/{instance_id}'
 
     return instance

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/get_instance_detail.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/get_instance_detail.py
@@ -91,6 +91,6 @@ async def get_instance_detail(
         raise ValueError(f'Instance {instance_id} not found')
 
     instance = format_instance_detail(instances[0])
-    instance.resource_uri = 'aws-rds://db-instance/{instance_id}'
+    instance.resource_uri = f'aws-rds://db-instance/{instance_id}'
 
     return instance

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/list_instances.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/list_instances.py
@@ -18,7 +18,7 @@ from ...common.connection import RDSConnectionManager
 from ...common.decorator import handle_exceptions
 from ...common.server import mcp
 from ...common.utils import handle_paginated_aws_api_call
-from .utils import InstanceSummaryModel, format_instance_summary
+from .utils import format_instance_summary, InstanceSummaryModel
 from loguru import logger
 from pydantic import BaseModel, Field
 from typing import List
@@ -58,7 +58,7 @@ Each instance object contains:
 
 
 class InstanceSummaryListModel(BaseModel):
-    """DB instance summary list model."""
+    """DB instance list model."""
 
     instances: List[InstanceSummaryModel] = Field(
         default_factory=list, description='List of DB instances'
@@ -75,10 +75,15 @@ class InstanceSummaryListModel(BaseModel):
 )
 @handle_exceptions
 async def list_instances() -> InstanceSummaryListModel:
-    """Get list of all RDS instances as a resource.
+    """List all RDS instances.
+
+    Retrieves a complete list of all RDS database instances in the current AWS region,
+    including Aurora instances and standard RDS instances, with pagination handling
+    for large result sets.
 
     Returns:
-        JSON string with instance list
+        JSON string with formatted instance information including identifiers,
+        endpoints, engine details, and other relevant metadata
     """
     logger.info('Getting instance list resource')
     rds_client = RDSConnectionManager.get_connection()

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/list_performance_reports.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/list_performance_reports.py
@@ -18,6 +18,7 @@ from ...common.connection import PIConnectionManager
 from ...common.decorator import handle_exceptions
 from ...common.server import mcp
 from ...common.utils import convert_datetime_to_string
+from ...context import Context
 from pydantic import BaseModel, Field
 from typing import List, Literal
 
@@ -119,7 +120,7 @@ async def list_performance_reports(
     reports: List[PerformanceReportSummary] = []
 
     next_token = None
-    max_results = 20
+    max_results = Context.max_items()
 
     while True:
         if next_token:

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/list_performance_reports.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/list_performance_reports.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Resource for listing availble RDS DB Performance Reports."""
+"""Resource for listing available RDS DB Performance Reports."""
 
 from ...common.connection import PIConnectionManager
 from ...common.decorator import handle_exceptions
@@ -20,7 +20,7 @@ from ...common.server import mcp
 from ...common.utils import convert_datetime_to_string
 from ...context import Context
 from pydantic import BaseModel, Field
-from typing import List, Literal
+from typing import List, Literal, Optional
 
 
 LIST_PERFORMANCE_REPORTS_DOCSTRING = """List all available performance reports for a specific Amazon RDS instance.
@@ -76,17 +76,19 @@ class PerformanceReportSummary(BaseModel):
     """
 
     # Models the AnalysisReportSummaryTypeDef class which has no required fields
-    analysis_report_id: str | None = Field(
+    analysis_report_id: Optional[str] = Field(
         None, description='Unique identifier for the performance report'
     )
-    create_time: str | None = Field(None, description='Time when the report was created')
-    start_time: str | None = Field(None, description='Start time of the analysis period')
-    end_time: str | None = Field(None, description='End time of the analysis period')
-    status: Literal['RUNNING', 'SUCCEEDED', 'FAILED'] | None = None
+    create_time: Optional[str] = Field(None, description='Time when the report was created')
+    start_time: Optional[str] = Field(None, description='Start time of the analysis period')
+    end_time: Optional[str] = Field(None, description='End time of the analysis period')
+    status: Optional[Literal['RUNNING', 'SUCCEEDED', 'FAILED']] = Field(
+        None, description='Current status of the report'
+    )
 
 
 class PerformanceReportListModel(BaseModel):
-    """DB cluster list model."""
+    """Performance report list model for RDS instances."""
 
     reports: List[PerformanceReportSummary] = Field(
         default_factory=list, description='List of performance reports for a RDS instance'
@@ -114,46 +116,50 @@ async def list_performance_reports(
         dbi_resource_identifier: The DB instance resource identifier
 
     Returns:
-        JSON string with list of performance reports
+        Performance report list model containing reports and metadata
     """
+    if not dbi_resource_identifier:
+        raise ValueError('The DB instance resource identifier must be provided')
+
     pi_client = PIConnectionManager.get_connection()
     reports: List[PerformanceReportSummary] = []
-
-    next_token = None
     max_results = Context.max_items()
+    next_token = None
 
     while True:
-        if next_token:
-            response = pi_client.list_performance_analysis_reports(
-                ServiceType='RDS',
-                Identifier=dbi_resource_identifier,
-                MaxResults=max_results,
-                NextToken=next_token,
-            )
-        else:
-            response = pi_client.list_performance_analysis_reports(
-                ServiceType='RDS', Identifier=dbi_resource_identifier, MaxResults=max_results
-            )
+        request_params = {
+            'ServiceType': 'RDS',
+            'Identifier': dbi_resource_identifier,
+            'MaxResults': max_results,
+        }
 
-        for report in response.get('AnalysisReports', []):
-            reports.append(
-                PerformanceReportSummary(
-                    analysis_report_id=report.get('AnalysisReportId'),
-                    create_time=convert_datetime_to_string(report.get('CreateTime')),
-                    start_time=convert_datetime_to_string(report.get('StartTime')),
-                    end_time=convert_datetime_to_string(report.get('EndTime')),
-                    status=report.get('Status'),
+        if next_token:
+            request_params['NextToken'] = next_token
+
+        response = pi_client.list_performance_analysis_reports(**request_params)
+
+        if 'AnalysisReports' in response:
+            for report in response['AnalysisReports']:
+                reports.append(
+                    PerformanceReportSummary(
+                        analysis_report_id=report.get('AnalysisReportId'),
+                        create_time=convert_datetime_to_string(report.get('CreateTime')),
+                        start_time=convert_datetime_to_string(report.get('StartTime')),
+                        end_time=convert_datetime_to_string(report.get('EndTime')),
+                        status=report.get('Status'),
+                    )
                 )
-            )
 
         if 'NextToken' not in response:
             break
 
         next_token = response.get('NextToken')
 
+    resource_uri = f'aws-rds://db-instance/{dbi_resource_identifier}/performance_report'
+
     result = PerformanceReportListModel(
         reports=reports,
         count=len(reports),
-        resource_uri='aws-rds://db-instance/{dbi_resource_identifier}/performance_report',
+        resource_uri=resource_uri,
     )
     return result

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/utils.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/utils.py
@@ -20,8 +20,8 @@ from ...common.models import (
     InstanceStorage,
     VpcSecurityGroup,
 )
-from pydantic import BaseModel, Field
 from typing import Dict, List, Optional
+from pydantic import BaseModel, Field
 from mypy_boto3_rds.type_defs import DBInstanceTypeDef
 
 
@@ -42,21 +42,25 @@ class InstanceSummaryModel(BaseModel):
     resource_uri: Optional[str] = Field(None, description='The resource URI for this instance')
 
 
+
 def format_instance_summary(instance: DBInstanceTypeDef) -> InstanceSummaryModel:
-    """Format instance information into a simplified summary model for list views.
+    """Format instance information into a simplified model for list views.
+    
+    This returns a simplified InstanceSummaryModel with only essential fields
+    to provide a high-level overview of instances.
 
     Args:
         instance: Raw instance data from AWS API response
 
     Returns:
-        Formatted instance summary information as an InstanceSummaryModel object
+        Formatted instance information as an InstanceSummaryModel object
     """
     tags = {}
     if instance.get('TagList'):
         for tag in instance.get('TagList', []):
             if 'Key' in tag and 'Value' in tag:
                 tags[tag['Key']] = tag['Value']
-
+                
     return InstanceSummaryModel(
         instance_id=instance.get('DBInstanceIdentifier', ''),
         dbi_resource_id=instance.get('DbiResourceId'),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

 Changed pagination utility to use pagination objects rather using manual pagination as advised by [boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/paginators.html) docs. Updated all functions accordingly.
 
 Improved code quality of `list_performance_reports`

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
