### PR TITLE
Fix/rds control plane model imports

### DIFF
--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/common/models.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/common/models.py
@@ -18,6 +18,31 @@ from pydantic import BaseModel, Field
 from typing import Dict, List, Optional
 
 
+class ClusterSummaryModel(BaseModel):
+    """Simplified DB cluster model for list views."""
+
+    cluster_id: str = Field(description='The DB cluster identifier')
+    db_cluster_arn: Optional[str] = Field(None, description='The ARN of the DB cluster')
+    db_cluster_resource_id: Optional[str] = Field(None, description='The resource ID of the DB cluster')
+    status: str = Field(description='The current status of the DB cluster')
+    engine: str = Field(description='The database engine')
+    engine_version: Optional[str] = Field(None, description='The version of the database engine')
+    availability_zones: List[str] = Field(default_factory=list, description='The AZs where the cluster instances can be created')
+    multi_az: bool = Field(
+        description='Whether the DB cluster has instances in multiple Availability Zones'
+    )
+    tag_list: Dict[str, str] = Field(default_factory=dict, description='A list of tags')
+    resource_uri: Optional[str] = Field(None, description='The resource URI for this cluster')
+
+
+class ClusterListModel(BaseModel):
+    """DB cluster list model."""
+
+    clusters: List[ClusterSummaryModel] = Field(description='List of DB clusters')
+    count: int = Field(description='Number of DB clusters')
+    resource_uri: str = Field(description='The resource URI for clusters')
+
+
 class VpcSecurityGroup(BaseModel):
     """VPC security group model."""
 
@@ -91,6 +116,23 @@ class InstanceStorage(BaseModel):
     encrypted: Optional[bool] = Field(None, description='Whether the storage is encrypted')
 
 
+class InstanceSummaryModel(BaseModel):
+    """Simplified DB instance model for list views."""
+
+    instance_id: str = Field(description='The DB instance identifier')
+    dbi_resource_id: Optional[str] = Field(None, description='The AWS Region-unique, immutable identifier for the DB instance')
+    status: str = Field(description='The current status of the DB instance')
+    engine: str = Field(description='The database engine')
+    engine_version: Optional[str] = Field(None, description='The version of the database engine')
+    instance_class: str = Field(description='The compute and memory capacity class of the DB instance')
+    availability_zone: Optional[str] = Field(None, description='The Availability Zone of the DB instance')
+    multi_az: bool = Field(description='Whether the DB instance is a Multi-AZ deployment')
+    publicly_accessible: bool = Field(description='Whether the DB instance is publicly accessible')
+    db_cluster: Optional[str] = Field(None, description='The DB cluster identifier, if this is a member of a DB cluster')
+    tag_list: Dict[str, str] = Field(default_factory=dict, description='A list of tags')
+    resource_uri: Optional[str] = Field(None, description='The resource URI for this instance')
+
+
 class InstanceModel(BaseModel):
     """DB instance model."""
 
@@ -130,3 +172,11 @@ class InstanceModel(BaseModel):
         None, description='The AWS Region-unique, immutable identifier for the DB instance'
     )
     resource_uri: Optional[str] = Field(None, description='The resource URI for this instance')
+
+
+class InstanceSummaryListModel(BaseModel):
+    """DB instance list model."""
+
+    instances: List[InstanceSummaryModel] = Field(description='List of DB instances')
+    count: int = Field(description='Number of DB instances')
+    resource_uri: str = Field(description='The resource URI for instances')

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_cluster/list_clusters.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_cluster/list_clusters.py
@@ -19,7 +19,7 @@ from ...common.decorator import handle_exceptions
 from ...common.models import ClusterModel, ClusterListModel
 from ...common.server import mcp
 from ...common.utils import handle_paginated_aws_api_call
-from .utils import ClusterSummaryModel, format_cluster_summary
+from .utils import format_cluster_summary
 from loguru import logger
 
 

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_cluster/utils.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_cluster/utils.py
@@ -17,29 +17,14 @@
 from ...common.models import (
     ClusterMember,
     ClusterModel,
+    ClusterSummaryModel,
     VpcSecurityGroup,
 )
-from pydantic import BaseModel, Field
-from typing import Dict, List, Optional
+from pydantic import BaseModel
+from typing import Dict
 from ...common.utils import convert_datetime_to_string
 from mypy_boto3_rds.type_defs import DBClusterTypeDef
 
-
-class ClusterSummaryModel(BaseModel):
-    """Simplified DB cluster model for list views."""
-
-    cluster_id: str = Field(description='The DB cluster identifier')
-    db_cluster_arn: Optional[str] = Field(None, description='The ARN of the DB cluster')
-    db_cluster_resource_id: Optional[str] = Field(None, description='The resource ID of the DB cluster')
-    status: str = Field(description='The current status of the DB cluster')
-    engine: str = Field(description='The database engine')
-    engine_version: Optional[str] = Field(None, description='The version of the database engine')
-    availability_zones: List[str] = Field(default_factory=list, description='The AZs where the cluster instances can be created')
-    multi_az: bool = Field(
-        description='Whether the DB cluster has instances in multiple Availability Zones'
-    )
-    tag_list: Dict[str, str] = Field(default_factory=dict, description='A list of tags')
-    resource_uri: Optional[str] = Field(None, description='The resource URI for this cluster')
 
 
 def format_cluster_summary(cluster: DBClusterTypeDef) -> ClusterSummaryModel:

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/list_instances.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/list_instances.py
@@ -16,9 +16,10 @@
 
 from ...common.connection import RDSConnectionManager
 from ...common.decorator import handle_exceptions
+from ...common.models import InstanceSummaryListModel
 from ...common.server import mcp
 from ...common.utils import handle_paginated_aws_api_call
-from .utils import format_instance_summary, InstanceSummaryModel
+from .utils import format_instance_summary
 from loguru import logger
 from pydantic import BaseModel, Field
 from typing import List

--- a/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/utils.py
+++ b/src/rds-control-plane-mcp-server/awslabs/rds_control_plane_mcp_server/resources/db_instance/utils.py
@@ -18,28 +18,12 @@ from ...common.models import (
     InstanceEndpoint,
     InstanceModel,
     InstanceStorage,
+    InstanceSummaryModel,
     VpcSecurityGroup,
 )
-from typing import Dict, List, Optional
-from pydantic import BaseModel, Field
+from typing import Dict
 from mypy_boto3_rds.type_defs import DBInstanceTypeDef
 
-
-class InstanceSummaryModel(BaseModel):
-    """Simplified DB instance model for list views."""
-
-    instance_id: str = Field(description='The DB instance identifier')
-    dbi_resource_id: Optional[str] = Field(None, description='The AWS Region-unique, immutable identifier for the DB instance')
-    status: str = Field(description='The current status of the DB instance')
-    engine: str = Field(description='The database engine')
-    engine_version: Optional[str] = Field(None, description='The version of the database engine')
-    instance_class: str = Field(description='The compute and memory capacity class of the DB instance')
-    availability_zone: Optional[str] = Field(None, description='The Availability Zone of the DB instance')
-    multi_az: bool = Field(description='Whether the DB instance is a Multi-AZ deployment')
-    publicly_accessible: bool = Field(description='Whether the DB instance is publicly accessible')
-    db_cluster: Optional[str] = Field(None, description='The DB cluster identifier, if this is a member of a DB cluster')
-    tag_list: Dict[str, str] = Field(default_factory=dict, description='A list of tags')
-    resource_uri: Optional[str] = Field(None, description='The resource URI for this instance')
 
 
 


### PR DESCRIPTION
**errors:** 
- `ImportError: cannot import name 'ClusterListModel' from 'awslabs.rds_control_plane_mcp_server.common.models'`

- `NameError: name 'InstanceSummaryListModel' is not defined. Did you mean: 'InstanceSummaryModel'?`

**fixes:**
- add the missing `ClusterListModel` class to the common models file
- add the missing `InstanceSummaryListModel` class to the common models file
- move `ClusterSummaryModel` from db_cluster/utils.py to common/models.py to resolve circular imports
- move `InstanceSummaryModel` from db_instance/utils.py to common/models.py to resolve circular imports
- update import statements in the affected files to reference the models from their new location
